### PR TITLE
Topic/aaron/languagetool http2

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -143,7 +143,7 @@ could fail with duplicate numbers
  OmegaT 3.6.0 update 3
 ----------------------------------------------------------------------
   0 Enhancement
-  3 Bug fixes
+  4 Bug fixes
   0 Localisation update
 ----------------------------------------------------------------------
 3.6.0 update 3 vs 3.6.0 update 2
@@ -157,6 +157,8 @@ could fail with duplicate numbers
 
   - Incorrect search result highlighting with custom colors
   https://sourceforge.net/p/omegat/bugs/835/
+
+  - Tag fix failure when tag has same offset in source and target
 
 ----------------------------------------------------------------------
  OmegaT 3.6.0 update 2 (2016-07-27)

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -602,17 +602,6 @@ GUI_PROJECT_UNIQUE_SEGMENTS=Number of unique segments
 GUI_PROJECT_TRANSLATED=Translated unique segments
 
 
-# Help Frame
-HF_WINDOW_TITLE=User's Manual
-
-HF_CANT_FIND_HELP=Cannot locate help file:
-
-HF_ERROR_EXTLINK_TITLE=Cannot open the link {0}
-
-HF_ERROR_EXTLINK_MSG=User's Manual viewer does not support navigation to external links. \
-    To access this link, either copy and paste the URL to your Web browser, \
-    or open the User's Manual in your Web browser ({0} file).
-
 # immortalize the BeOS 404 messages (some modified a bit for context)
 HF_HAIKU_1=Exciting help page<p>Gossamer threads hold you back<p>404 not found
 

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -388,11 +388,11 @@ public class Main {
     
     /**
      * Validates tags according to command line specs:
-     * --tag-validation=[abort|warn]
-     * 
-     * On abort, the program is aborted when tag validation finds errors. 
-     * On warn the errors are printed but the program continues.
-     * In all other cases no tag validation is done.
+     * <code>--tag-validation=[abort|warn]</code>
+     * <p>
+     * On abort, the program is aborted when tag validation finds errors. On
+     * warn the errors are printed but the program continues. In all other cases
+     * no tag validation is done.
      */
     private static void validateTagsConsoleMode() {
         TAG_VALIDATION_MODE mode = TAG_VALIDATION_MODE.parse(params.get(CLIParameters.TAG_VALIDATION));

--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -237,7 +237,8 @@ public class Core {
         Core.registerMarker(new ReplaceMarker());
         Core.registerMarker(new ComesFromAutoTMMarker());
         Core.registerMarker(new FontFallbackMarker());
-        Core.registerMarker(new LanguageToolWrapper());
+
+        LanguageToolWrapper.init();
 
         segmenter = new Segmenter(Preferences.getSRX());
         filterMaster = new FilterMaster(Preferences.getFilters());

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -188,7 +188,7 @@ public class Searcher {
         default:
             // escape the search string, it's not supposed to be a regular
             // expression
-            text = StaticUtils.escapeNonRegex(text, false);
+            text = StaticUtils.globToRegex(text);
 
             // space match nbsp (\u00a0)
             if (expression.spaceMatchNbsp) {
@@ -216,7 +216,7 @@ public class Searcher {
                     if (!word.isEmpty()) {
                         // escape the word, if it's not supposed to be a regular
                         // expression
-                        word = StaticUtils.escapeNonRegex(word, false);
+                        word = StaticUtils.globToRegex(word);
 
                         // create a matcher for the word
                         m_matchers.add(Pattern.compile(word, flags).matcher(""));
@@ -239,8 +239,9 @@ public class Searcher {
             break;
         }
         // create a matcher for the author search string
-        if (expression.searchExpressionType != SearchExpression.SearchExpressionType.REGEXP)
-            author = StaticUtils.escapeNonRegex(author, false);
+        if (expression.searchExpressionType != SearchExpression.SearchExpressionType.REGEXP) {
+            author = StaticUtils.globToRegex(author);
+        }
 
         m_author = Pattern.compile(author, flags).matcher("");
 

--- a/src/org/omegat/core/spellchecker/ISpellChecker.java
+++ b/src/org/omegat/core/spellchecker/ISpellChecker.java
@@ -31,6 +31,8 @@ package org.omegat.core.spellchecker;
 
 import java.util.List;
 
+import org.omegat.util.Token;
+
 /**
  * Interface for access to spell checker.
  * 
@@ -68,4 +70,10 @@ public interface ISpellChecker {
      * Add a word to the list of ignored words
      */
     void ignoreWord(String word);
+
+    /**
+     * Get a list of misspelled tokens from the given text
+     */
+    List<Token> getMisspelledTokens(String text);
+
 }

--- a/src/org/omegat/core/spellchecker/SpellChecker.java
+++ b/src/org/omegat/core/spellchecker/SpellChecker.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
@@ -50,11 +51,13 @@ import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.core.events.IProjectEventListener;
+import org.omegat.tokenizer.ITokenizer.StemmingMode;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.Preferences;
 import org.omegat.util.StaticUtils;
+import org.omegat.util.Token;
 
 /**
  * Common spell checker interface for use any spellchecker providers.
@@ -407,5 +410,11 @@ public class SpellChecker implements ISpellChecker {
     private static String normalize(String word) {
         // U+2019 RIGHT SINGLE QUOTATION MARK to U+0027 APOSTROPHE
         return word.replace('\u2019', '\'');
+    }
+
+    @Override
+    public List<Token> getMisspelledTokens(String text) {
+        return Stream.of(Core.getProject().getTargetTokenizer().tokenizeWords(text, StemmingMode.NONE))
+                .filter(tok -> !isCorrect(tok.getTextFromString(text))).collect(Collectors.toList());
     }
 }

--- a/src/org/omegat/core/spellchecker/SpellCheckerMarker.java
+++ b/src/org/omegat/core/spellchecker/SpellCheckerMarker.java
@@ -25,8 +25,8 @@
 
 package org.omegat.core.spellchecker;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.swing.text.Highlighter.HighlightPainter;
 
@@ -35,8 +35,6 @@ import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.editor.UnderlineFactory;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
-import org.omegat.tokenizer.ITokenizer.StemmingMode;
-import org.omegat.util.Token;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -59,17 +57,12 @@ public class SpellCheckerMarker implements IMarker {
             // spell checker disabled
             return null;
         }
-        List<Mark> result = new ArrayList<Mark>();
-        for (Token tok : Core.getProject().getTargetTokenizer().tokenizeWords(translationText, StemmingMode.NONE)) {
-            String word = tok.getTextFromString(translationText);
-            if (!Core.getSpellChecker().isCorrect(word)) {
-                int st = tok.getOffset();
-                int en = st + tok.getLength();
-                Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, st, en);
-                m.painter = PAINTER;
-                result.add(m);
-            }
-        }
-        return result;
+        return Core.getSpellChecker().getMisspelledTokens(translationText).stream().map(tok -> {
+            int st = tok.getOffset();
+            int en = st + tok.getLength();
+            Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, st, en);
+            m.painter = PAINTER;
+            return m;
+        }).collect(Collectors.toList());
     }
 }

--- a/src/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -286,8 +286,8 @@ public class CalcMatchStatistics extends LongProcessThread {
         } catch (StoppedException | LongProcessInterruptedException ex) {
         }
         long endTime = System.currentTimeMillis();
-        Logger.getLogger(getClass().getName()).fine(String.format("Calc similarity took %d s (%s)",
-                (endTime - startTime) / 1000, doParallel ? "parallel" : "sequential"));
+        Logger.getLogger(getClass().getName()).fine(String.format("Calc similarity took %.3f s (%s)",
+                (endTime - startTime) / 1000f, doParallel ? "parallel" : "sequential"));
         return Optional.ofNullable(result);
     }
 

--- a/src/org/omegat/core/tagvalidation/ErrorReport.java
+++ b/src/org/omegat/core/tagvalidation/ErrorReport.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
 import org.omegat.util.OStrings;
 import org.omegat.util.TagUtil.Tag;
 
@@ -50,14 +51,34 @@ public class ErrorReport {
 
     final public SourceTextEntry ste;
     final public String source;
+    final public TMXEntry tmxEntry;
     final public String translation;
     final public int entryNum;
 
-    public ErrorReport(SourceTextEntry ste, String translation) {
+    public ErrorReport(SourceTextEntry ste, TMXEntry tmxEntry) {
         this.ste = ste;
-        this.source = ste != null ? ste.getSrcText() : null;
+        this.source = ste.getSrcText();
+        this.tmxEntry = tmxEntry;
+        this.translation = tmxEntry.translation;
+        this.entryNum = ste.entryNum();
+    }
+
+    /**
+     * For testing
+     */
+    ErrorReport() {
+        this((String) null, (String) null);
+    }
+
+    /**
+     * For testing
+     */
+    ErrorReport(String source, String translation) {
+        this.ste = null;
+        this.tmxEntry = null;
+        this.entryNum = -1;
+        this.source = source;
         this.translation = translation;
-        this.entryNum = ste != null ? ste.entryNum() : -1;
     }
 
     public boolean isEmpty() {

--- a/src/org/omegat/gui/align/AlignPanelController.java
+++ b/src/org/omegat/gui/align/AlignPanelController.java
@@ -855,7 +855,8 @@ public class AlignPanelController {
         loader = new SwingWorker<List<MutableBead>, Object>() {
             @Override
             protected List<MutableBead> doInBackground() throws Exception {
-                return aligner.alignImpl().map(MutableBead::new).collect(Collectors.toList());
+                return aligner.alignImpl().filter(o -> !isCancelled()).map(MutableBead::new)
+                        .collect(Collectors.toList());
             }
 
             @Override

--- a/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
+++ b/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
@@ -242,6 +242,9 @@ public class DictionaryInstallerDialog extends JDialog {
             List<String> selection = dictionaryList.getSelectedValuesList();
             List<String> completed = new ArrayList<>();
             for (Object o : selection) {
+                if (isCancelled()) {
+                    break;
+                }
                 // install the respective dictionaries
                 String item = (String) o;
                 String langCode = item.substring(0, item.indexOf(" "));

--- a/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
+++ b/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
@@ -68,7 +68,7 @@ public class DictionaryInstallerDialog extends JDialog {
      */
     private final DefaultListModel<String> listModel = new DefaultListModel<>();
     
-    private SwingWorker<List<String>, Object> loader = null;
+    private LoaderWorker loader = null;
     private InstallerWorker installer = null;
 
     /** Creates new form DictionaryInstallerDialog */
@@ -97,6 +97,7 @@ public class DictionaryInstallerDialog extends JDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowOpened(WindowEvent e) {
+                progressBar.setVisible(true);
                 loader = new LoaderWorker();
                 loader.execute();
             }
@@ -108,7 +109,6 @@ public class DictionaryInstallerDialog extends JDialog {
         @Override
         protected List<String> doInBackground() throws Exception {
             //Connect with remote URL to get list of dictionaries.
-            progressBar.setVisible(true);
             return dicMan.getInstallableDictionaryNameList();
         }
 
@@ -230,7 +230,7 @@ public class DictionaryInstallerDialog extends JDialog {
         installer.execute();
     }//GEN-LAST:event_installButtonActionPerformed
 
-    private class InstallerWorker extends SwingWorker<List<String>,Object> {
+    private class InstallerWorker extends SwingWorker<List<String>, String> {
 
         private final Cursor HOURGLASS_CURSOR = Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR);
         private Cursor oldCursor;
@@ -241,12 +241,11 @@ public class DictionaryInstallerDialog extends JDialog {
             setCursor(HOURGLASS_CURSOR);
             List<String> selection = dictionaryList.getSelectedValuesList();
             List<String> completed = new ArrayList<>();
-            for (Object o : selection) {
+            for (String item : selection) {
                 if (isCancelled()) {
                     break;
                 }
                 // install the respective dictionaries
-                String item = (String) o;
                 String langCode = item.substring(0, item.indexOf(" "));
                 try {
                     dicMan.installRemoteDictionary(langCode);
@@ -263,7 +262,7 @@ public class DictionaryInstallerDialog extends JDialog {
         }
 
         @Override
-        protected void process(List<Object> chunks) {
+        protected void process(List<String> chunks) {
             chunks.forEach(listModel::removeElement);
         }
         

--- a/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
+++ b/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
@@ -244,7 +244,7 @@ public class DictionaryInstallerDialog extends JDialog {
             for (Object o : selection) {
                 // install the respective dictionaries
                 String item = (String) o;
-                String langCode = (item).substring(0, item.indexOf(" "));
+                String langCode = item.substring(0, item.indexOf(" "));
                 try {
                     dicMan.installRemoteDictionary(langCode);
                     completed.add(item);
@@ -261,13 +261,13 @@ public class DictionaryInstallerDialog extends JDialog {
 
         @Override
         protected void process(List<Object> chunks) {
-            chunks.forEach(o -> listModel.removeElement(o));
+            chunks.forEach(listModel::removeElement);
         }
         
         @Override
         protected void done() {
             try {
-                get().forEach(o -> listModel.removeElement(o));
+                get().forEach(listModel::removeElement);
             } catch (InterruptedException | ExecutionException e) {
                 // Ignore
             }

--- a/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
+++ b/src/org/omegat/gui/dialogs/DictionaryInstallerDialog.java
@@ -103,7 +103,7 @@ public class DictionaryInstallerDialog extends JDialog {
         });
     }
 
-    private class LoaderWorker extends SwingWorker<List<String>,Object> {
+    private class LoaderWorker extends SwingWorker<List<String>, Void> {
 
         @Override
         protected List<String> doInBackground() throws Exception {

--- a/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.form
+++ b/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.form
@@ -10,7 +10,6 @@
     <Property name="title" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
       <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_DIALOG_TITLE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
     </Property>
-    <Property name="resizable" type="boolean" value="false"/>
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
@@ -26,34 +25,12 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-24,0,0,2,111"/>
   </AuxValues>
 
-  <Layout>
-    <DimensionLayout dim="0">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Component id="typePanel" max="32767" attributes="0"/>
-          <Component id="externalOptionsPanel" alignment="0" max="32767" attributes="0"/>
-          <Component id="bottomPanel" alignment="0" pref="610" max="32767" attributes="0"/>
-          <Component id="rulesPanel" alignment="1" max="32767" attributes="0"/>
-      </Group>
-    </DimensionLayout>
-    <DimensionLayout dim="1">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
-              <Component id="typePanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="externalOptionsPanel" min="-2" pref="138" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="rulesPanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
-              <Component id="bottomPanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-  </Layout>
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
   <SubComponents>
-    <Container class="javax.swing.JPanel" name="typePanel">
+    <Container class="javax.swing.JPanel" name="topPanel">
       <Properties>
         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
           <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
@@ -63,172 +40,279 @@
           </Border>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+          <BorderConstraints direction="North"/>
+        </Constraint>
+      </Constraints>
 
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="bridgeNativeRadioButton" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                  <Component id="bridgeRemoteRadioButton" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                  <Component id="bridgeLocalRadioButton" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="32767" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="bridgeNativeRadioButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="bridgeRemoteRadioButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="bridgeLocalRadioButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace max="32767" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-      </Layout>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
       <SubComponents>
-        <Component class="javax.swing.JRadioButton" name="bridgeNativeRadioButton">
+        <Container class="javax.swing.JPanel" name="typePanel">
           <Properties>
-            <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
-              <ComponentRef name="buttonGroup1"/>
-            </Property>
-            <Property name="selected" type="boolean" value="true"/>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_NATIVE_BRIDGE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-            <Property name="name" type="java.lang.String" value="" noResource="true"/>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="bridgeNativeRadioButtonActionPerformed"/>
-          </Events>
-        </Component>
-        <Component class="javax.swing.JRadioButton" name="bridgeRemoteRadioButton">
-          <Properties>
-            <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
-              <ComponentRef name="buttonGroup1"/>
-            </Property>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_REMOTE_BRIDGE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-            <Property name="name" type="java.lang.String" value="" noResource="true"/>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="bridgeRemoteRadioButtonActionPerformed"/>
-          </Events>
-        </Component>
-        <Component class="javax.swing.JRadioButton" name="bridgeLocalRadioButton">
-          <Properties>
-            <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
-              <ComponentRef name="buttonGroup1"/>
-            </Property>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_LOCAL_BRIDGE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+              <Border info="org.netbeans.modules.form.compat2.border.EmptyBorderInfo">
+                <EmptyBorder bottom="10" left="10" right="10" top="10"/>
+              </Border>
             </Property>
           </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="bridgeLocalRadioButtonActionPerformed"/>
-          </Events>
-        </Component>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="Center"/>
+            </Constraint>
+          </Constraints>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout"/>
+          <SubComponents>
+            <Component class="javax.swing.JRadioButton" name="bridgeNativeRadioButton">
+              <Properties>
+                <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                  <ComponentRef name="buttonGroup1"/>
+                </Property>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_NATIVE_BRIDGE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </Property>
+                <Property name="name" type="java.lang.String" value="" noResource="true"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="bridgeNativeRadioButtonActionPerformed"/>
+              </Events>
+            </Component>
+            <Component class="javax.swing.JRadioButton" name="bridgeRemoteRadioButton">
+              <Properties>
+                <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                  <ComponentRef name="buttonGroup1"/>
+                </Property>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_REMOTE_BRIDGE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </Property>
+                <Property name="name" type="java.lang.String" value="" noResource="true"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="bridgeRemoteRadioButtonActionPerformed"/>
+              </Events>
+            </Component>
+            <Component class="javax.swing.JRadioButton" name="bridgeLocalRadioButton">
+              <Properties>
+                <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                  <ComponentRef name="buttonGroup1"/>
+                </Property>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_LOCAL_BRIDGE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="bridgeLocalRadioButtonActionPerformed"/>
+              </Events>
+            </Component>
+          </SubComponents>
+        </Container>
       </SubComponents>
     </Container>
-    <Container class="javax.swing.JPanel" name="externalOptionsPanel">
-      <Properties>
-        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
-          <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-            <TitledBorder title="External server settings">
-              <ResourceString PropertyName="titleX" bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_EXTERNAL_SETTINGS" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </TitledBorder>
-          </Border>
-        </Property>
-      </Properties>
+    <Container class="javax.swing.JPanel" name="centerPanel">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+          <BorderConstraints direction="Center"/>
+        </Constraint>
+      </Constraints>
 
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" alignment="1" attributes="0">
-                          <Component id="directoryTextField" pref="454" max="32767" attributes="0"/>
-                          <EmptySpace type="separate" max="-2" attributes="0"/>
-                          <Component id="directoryChooseButton" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <Component id="urlTextField" alignment="1" max="32767" attributes="0"/>
-                      <Group type="102" attributes="0">
-                          <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="urlLabel" min="-2" max="-2" attributes="0"/>
-                              <Component id="localPathLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                      </Group>
-                  </Group>
-                  <EmptySpace max="-2" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="urlLabel" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="32767" attributes="0"/>
-                  <Component id="urlTextField" min="-2" pref="24" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="localPathLabel" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="directoryTextField" alignment="3" min="-2" pref="24" max="-2" attributes="0"/>
-                      <Component id="directoryChooseButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace min="-2" pref="40" max="-2" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-      </Layout>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
       <SubComponents>
-        <Component class="javax.swing.JTextField" name="directoryTextField">
+        <Container class="javax.swing.JPanel" name="externalOptionsPanel">
           <Properties>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
-          </Properties>
-        </Component>
-        <Component class="javax.swing.JLabel" name="localPathLabel">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_LOCAL_SERVER_PATH" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+              <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
+                <TitledBorder title="External server settings">
+                  <ResourceString PropertyName="titleX" bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_EXTERNAL_SETTINGS" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </TitledBorder>
+              </Border>
             </Property>
           </Properties>
-        </Component>
-        <Component class="javax.swing.JLabel" name="urlLabel">
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="North"/>
+            </Constraint>
+          </Constraints>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
+            <Property name="axis" type="int" value="3"/>
+          </Layout>
+          <SubComponents>
+            <Container class="javax.swing.JPanel" name="remotePanel">
+              <Properties>
+                <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+                  <Border info="org.netbeans.modules.form.compat2.border.EmptyBorderInfo">
+                    <EmptyBorder bottom="10" left="10" right="10" top="10"/>
+                  </Border>
+                </Property>
+              </Properties>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JLabel" name="urlLabel">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_URL" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                      <BorderConstraints direction="North"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JTextField" name="urlTextField">
+                  <Properties>
+                    <Property name="toolTipText" type="java.lang.String" value=""/>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                      <BorderConstraints direction="Center"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+              </SubComponents>
+            </Container>
+            <Container class="javax.swing.JPanel" name="localPanel">
+              <Properties>
+                <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+                  <Border info="org.netbeans.modules.form.compat2.border.EmptyBorderInfo">
+                    <EmptyBorder bottom="10" left="10" right="10" top="0"/>
+                  </Border>
+                </Property>
+              </Properties>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JLabel" name="localPathLabel">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_LOCAL_SERVER_PATH" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                      <BorderConstraints direction="North"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Container class="javax.swing.JPanel" name="directoryPanel">
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                      <BorderConstraints direction="Center"/>
+                    </Constraint>
+                  </Constraints>
+
+                  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+                  <SubComponents>
+                    <Component class="javax.swing.JTextField" name="directoryTextField">
+                      <Properties>
+                        <Property name="toolTipText" type="java.lang.String" value=""/>
+                      </Properties>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                          <BorderConstraints direction="Center"/>
+                        </Constraint>
+                      </Constraints>
+                    </Component>
+                    <Component class="javax.swing.JButton" name="directoryChooseButton">
+                      <Properties>
+                        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                          <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_CHOOSE_BUTTON" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                        </Property>
+                      </Properties>
+                      <Events>
+                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="directoryChooseButtonActionPerformed"/>
+                      </Events>
+                      <AuxValues>
+                        <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+                      </AuxValues>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                          <BorderConstraints direction="East"/>
+                        </Constraint>
+                      </Constraints>
+                    </Component>
+                  </SubComponents>
+                </Container>
+              </SubComponents>
+            </Container>
+          </SubComponents>
+        </Container>
+        <Container class="javax.swing.JPanel" name="rulesPanel">
           <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_URL" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+              <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
+                <TitledBorder title="Rules">
+                  <ResourceString PropertyName="titleX" bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_RULES" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </TitledBorder>
+              </Border>
             </Property>
           </Properties>
-        </Component>
-        <Component class="javax.swing.JButton" name="directoryChooseButton">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_CHOOSE_BUTTON" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="directoryChooseButtonActionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
-          </AuxValues>
-        </Component>
-        <Component class="javax.swing.JTextField" name="urlTextField">
-          <Properties>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
-          </Properties>
-        </Component>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="Center"/>
+            </Constraint>
+          </Constraints>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+          <SubComponents>
+            <Container class="javax.swing.JScrollPane" name="rulesScrollPane">
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                  <BorderConstraints direction="Center"/>
+                </Constraint>
+              </Constraints>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JTree" name="rulesTree">
+                  <Properties>
+                    <Property name="showsRootHandles" type="boolean" value="true"/>
+                  </Properties>
+                </Component>
+              </SubComponents>
+            </Container>
+            <Container class="javax.swing.JPanel" name="rulesButtonsPanel">
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                  <BorderConstraints direction="South"/>
+                </Constraint>
+              </Constraints>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JButton" name="addRuleButton">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_ADD_NODOTS" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="addRuleButtonActionPerformed"/>
+                  </Events>
+                  <AuxValues>
+                    <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+                  </AuxValues>
+                </Component>
+                <Component class="javax.swing.JButton" name="deleteRuleButton">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_REMOVE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                    </Property>
+                    <Property name="toolTipText" type="java.lang.String" value=""/>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="deleteRuleButtonActionPerformed"/>
+                  </Events>
+                  <AuxValues>
+                    <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+                  </AuxValues>
+                </Component>
+              </SubComponents>
+            </Container>
+          </SubComponents>
+        </Container>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="bottomPanel">
@@ -237,136 +321,51 @@
           <Dimension value="[631, 40]"/>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+          <BorderConstraints direction="South"/>
+        </Constraint>
+      </Constraints>
 
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="1" attributes="0">
-                  <EmptySpace max="32767" attributes="0"/>
-                  <Component id="okButton" linkSize="1" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="cancelButton" linkSize="1" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace pref="11" max="32767" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="cancelButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="okButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-              </Group>
-          </Group>
-        </DimensionLayout>
-      </Layout>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
       <SubComponents>
-        <Component class="javax.swing.JButton" name="cancelButton">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_CANCEL" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cancelButtonActionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-        </Component>
-        <Component class="javax.swing.JButton" name="okButton">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_OK" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="okButtonActionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-        </Component>
-      </SubComponents>
-    </Container>
-    <Container class="javax.swing.JPanel" name="rulesPanel">
-      <Properties>
-        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
-          <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-            <TitledBorder title="Rules">
-              <ResourceString PropertyName="titleX" bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_RULES" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </TitledBorder>
-          </Border>
-        </Property>
-      </Properties>
+        <Container class="javax.swing.JPanel" name="buttonsPanel">
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="East"/>
+            </Constraint>
+          </Constraints>
 
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Component id="rulesScrollPane" alignment="0" pref="598" max="32767" attributes="0"/>
-              <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="addRuleButton" linkSize="3" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace type="separate" max="-2" attributes="0"/>
-                  <Component id="deleteRuleButton" linkSize="3" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="32767" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
-                  <Component id="rulesScrollPane" min="-2" pref="208" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="addRuleButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="deleteRuleButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-              </Group>
-          </Group>
-        </DimensionLayout>
-      </Layout>
-      <SubComponents>
-        <Container class="javax.swing.JScrollPane" name="rulesScrollPane">
-
-          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout"/>
           <SubComponents>
-            <Component class="javax.swing.JTree" name="rulesTree">
+            <Component class="javax.swing.JButton" name="cancelButton">
               <Properties>
-                <Property name="showsRootHandles" type="boolean" value="true"/>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_CANCEL" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </Property>
               </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cancelButtonActionPerformed"/>
+              </Events>
+              <AuxValues>
+                <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JButton" name="okButton">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_OK" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="okButtonActionPerformed"/>
+              </Events>
+              <AuxValues>
+                <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+              </AuxValues>
             </Component>
           </SubComponents>
         </Container>
-        <Component class="javax.swing.JButton" name="addRuleButton">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_ADD_NODOTS" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="addRuleButtonActionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-        </Component>
-        <Component class="javax.swing.JButton" name="deleteRuleButton">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_REMOVE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
-          </Properties>
-          <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="deleteRuleButtonActionPerformed"/>
-          </Events>
-          <AuxValues>
-            <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-        </Component>
       </SubComponents>
     </Container>
   </SubComponents>

--- a/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.form
+++ b/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.form
@@ -33,7 +33,7 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Component id="typePanel" max="32767" attributes="0"/>
           <Component id="externalOptionsPanel" alignment="0" max="32767" attributes="0"/>
-          <Component id="bottomPanel" alignment="0" pref="608" max="32767" attributes="0"/>
+          <Component id="bottomPanel" alignment="0" pref="610" max="32767" attributes="0"/>
           <Component id="rulesPanel" alignment="1" max="32767" attributes="0"/>
       </Group>
     </DimensionLayout>
@@ -253,7 +253,7 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace pref="15" max="32767" attributes="0"/>
+                  <EmptySpace pref="11" max="32767" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="cancelButton" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="okButton" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -334,6 +334,9 @@
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
           <SubComponents>
             <Component class="javax.swing.JTree" name="rulesTree">
+              <Properties>
+                <Property name="showsRootHandles" type="boolean" value="true"/>
+              </Properties>
             </Component>
           </SubComponents>
         </Container>

--- a/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
+++ b/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
@@ -626,33 +626,42 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
     private void initComponents() {
 
         buttonGroup1 = new javax.swing.ButtonGroup();
+        topPanel = new javax.swing.JPanel();
         typePanel = new javax.swing.JPanel();
         bridgeNativeRadioButton = new javax.swing.JRadioButton();
         bridgeRemoteRadioButton = new javax.swing.JRadioButton();
         bridgeLocalRadioButton = new javax.swing.JRadioButton();
+        centerPanel = new javax.swing.JPanel();
         externalOptionsPanel = new javax.swing.JPanel();
-        directoryTextField = new javax.swing.JTextField();
-        localPathLabel = new javax.swing.JLabel();
+        remotePanel = new javax.swing.JPanel();
         urlLabel = new javax.swing.JLabel();
-        directoryChooseButton = new javax.swing.JButton();
         urlTextField = new javax.swing.JTextField();
-        bottomPanel = new javax.swing.JPanel();
-        cancelButton = new javax.swing.JButton();
-        okButton = new javax.swing.JButton();
+        localPanel = new javax.swing.JPanel();
+        localPathLabel = new javax.swing.JLabel();
+        directoryPanel = new javax.swing.JPanel();
+        directoryTextField = new javax.swing.JTextField();
+        directoryChooseButton = new javax.swing.JButton();
         rulesPanel = new javax.swing.JPanel();
         rulesScrollPane = new javax.swing.JScrollPane();
         rulesTree = new javax.swing.JTree();
+        rulesButtonsPanel = new javax.swing.JPanel();
         addRuleButton = new javax.swing.JButton();
         deleteRuleButton = new javax.swing.JButton();
+        bottomPanel = new javax.swing.JPanel();
+        buttonsPanel = new javax.swing.JPanel();
+        cancelButton = new javax.swing.JButton();
+        okButton = new javax.swing.JButton();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle(OStrings.getString("GUI_LANGUAGETOOL_DIALOG_TITLE")); // NOI18N
-        setResizable(false);
 
-        typePanel.setBorder(javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_BRIDGE_TYPE"))); // NOI18N
+        topPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_BRIDGE_TYPE"))); // NOI18N
+        topPanel.setLayout(new java.awt.BorderLayout());
+
+        typePanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        typePanel.setLayout(new javax.swing.BoxLayout(typePanel, javax.swing.BoxLayout.LINE_AXIS));
 
         buttonGroup1.add(bridgeNativeRadioButton);
-        bridgeNativeRadioButton.setSelected(true);
         bridgeNativeRadioButton.setText(OStrings.getString("GUI_LANGUAGETOOL_NATIVE_BRIDGE")); // NOI18N
         bridgeNativeRadioButton.setName(""); // NOI18N
         bridgeNativeRadioButton.addActionListener(new java.awt.event.ActionListener() {
@@ -660,6 +669,7 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
                 bridgeNativeRadioButtonActionPerformed(evt);
             }
         });
+        typePanel.add(bridgeNativeRadioButton);
 
         buttonGroup1.add(bridgeRemoteRadioButton);
         bridgeRemoteRadioButton.setText(OStrings.getString("GUI_LANGUAGETOOL_REMOTE_BRIDGE")); // NOI18N
@@ -669,6 +679,7 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
                 bridgeRemoteRadioButtonActionPerformed(evt);
             }
         });
+        typePanel.add(bridgeRemoteRadioButton);
 
         buttonGroup1.add(bridgeLocalRadioButton);
         bridgeLocalRadioButton.setText(OStrings.getString("GUI_LANGUAGETOOL_LOCAL_BRIDGE")); // NOI18N
@@ -677,38 +688,38 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
                 bridgeLocalRadioButtonActionPerformed(evt);
             }
         });
+        typePanel.add(bridgeLocalRadioButton);
 
-        javax.swing.GroupLayout typePanelLayout = new javax.swing.GroupLayout(typePanel);
-        typePanel.setLayout(typePanelLayout);
-        typePanelLayout.setHorizontalGroup(
-            typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(typePanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(bridgeNativeRadioButton)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(bridgeRemoteRadioButton)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(bridgeLocalRadioButton)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-        );
-        typePanelLayout.setVerticalGroup(
-            typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(typePanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(bridgeNativeRadioButton)
-                    .addComponent(bridgeRemoteRadioButton)
-                    .addComponent(bridgeLocalRadioButton))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-        );
+        topPanel.add(typePanel, java.awt.BorderLayout.CENTER);
+
+        getContentPane().add(topPanel, java.awt.BorderLayout.NORTH);
+
+        centerPanel.setLayout(new java.awt.BorderLayout());
 
         externalOptionsPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_EXTERNAL_SETTINGS"))); // NOI18N
+        externalOptionsPanel.setLayout(new javax.swing.BoxLayout(externalOptionsPanel, javax.swing.BoxLayout.PAGE_AXIS));
 
-        directoryTextField.setToolTipText("");
-
-        localPathLabel.setText(OStrings.getString("GUI_LANGUAGETOOL_LOCAL_SERVER_PATH")); // NOI18N
+        remotePanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        remotePanel.setLayout(new java.awt.BorderLayout());
 
         urlLabel.setText(OStrings.getString("GUI_LANGUAGETOOL_URL")); // NOI18N
+        remotePanel.add(urlLabel, java.awt.BorderLayout.NORTH);
+
+        urlTextField.setToolTipText("");
+        remotePanel.add(urlTextField, java.awt.BorderLayout.CENTER);
+
+        externalOptionsPanel.add(remotePanel);
+
+        localPanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 10, 10, 10));
+        localPanel.setLayout(new java.awt.BorderLayout());
+
+        localPathLabel.setText(OStrings.getString("GUI_LANGUAGETOOL_LOCAL_SERVER_PATH")); // NOI18N
+        localPanel.add(localPathLabel, java.awt.BorderLayout.NORTH);
+
+        directoryPanel.setLayout(new java.awt.BorderLayout());
+
+        directoryTextField.setToolTipText("");
+        directoryPanel.add(directoryTextField, java.awt.BorderLayout.CENTER);
 
         directoryChooseButton.setText(OStrings.getString("GUI_LANGUAGETOOL_CHOOSE_BUTTON")); // NOI18N
         directoryChooseButton.addActionListener(new java.awt.event.ActionListener() {
@@ -716,87 +727,23 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
                 directoryChooseButtonActionPerformed(evt);
             }
         });
+        directoryPanel.add(directoryChooseButton, java.awt.BorderLayout.EAST);
 
-        urlTextField.setToolTipText("");
+        localPanel.add(directoryPanel, java.awt.BorderLayout.CENTER);
 
-        javax.swing.GroupLayout externalOptionsPanelLayout = new javax.swing.GroupLayout(externalOptionsPanel);
-        externalOptionsPanel.setLayout(externalOptionsPanelLayout);
-        externalOptionsPanelLayout.setHorizontalGroup(
-            externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(externalOptionsPanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, externalOptionsPanelLayout.createSequentialGroup()
-                        .addComponent(directoryTextField, javax.swing.GroupLayout.DEFAULT_SIZE, 454, Short.MAX_VALUE)
-                        .addGap(18, 18, 18)
-                        .addComponent(directoryChooseButton))
-                    .addComponent(urlTextField, javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addGroup(externalOptionsPanelLayout.createSequentialGroup()
-                        .addGroup(externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(urlLabel)
-                            .addComponent(localPathLabel))
-                        .addGap(0, 0, Short.MAX_VALUE)))
-                .addContainerGap())
-        );
-        externalOptionsPanelLayout.setVerticalGroup(
-            externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(externalOptionsPanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(urlLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(urlTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 24, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(localPathLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(directoryTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 24, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(directoryChooseButton))
-                .addGap(40, 40, 40))
-        );
+        externalOptionsPanel.add(localPanel);
 
-        bottomPanel.setPreferredSize(new java.awt.Dimension(631, 40));
-
-        org.openide.awt.Mnemonics.setLocalizedText(cancelButton, OStrings.getString("BUTTON_CANCEL")); // NOI18N
-        cancelButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                cancelButtonActionPerformed(evt);
-            }
-        });
-
-        org.openide.awt.Mnemonics.setLocalizedText(okButton, OStrings.getString("BUTTON_OK")); // NOI18N
-        okButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                okButtonActionPerformed(evt);
-            }
-        });
-
-        javax.swing.GroupLayout bottomPanelLayout = new javax.swing.GroupLayout(bottomPanel);
-        bottomPanel.setLayout(bottomPanelLayout);
-        bottomPanelLayout.setHorizontalGroup(
-            bottomPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, bottomPanelLayout.createSequentialGroup()
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(okButton)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(cancelButton)
-                .addContainerGap())
-        );
-
-        bottomPanelLayout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {cancelButton, okButton});
-
-        bottomPanelLayout.setVerticalGroup(
-            bottomPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(bottomPanelLayout.createSequentialGroup()
-                .addContainerGap(11, Short.MAX_VALUE)
-                .addGroup(bottomPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(cancelButton)
-                    .addComponent(okButton)))
-        );
+        centerPanel.add(externalOptionsPanel, java.awt.BorderLayout.NORTH);
 
         rulesPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_RULES"))); // NOI18N
+        rulesPanel.setLayout(new java.awt.BorderLayout());
 
         rulesTree.setShowsRootHandles(true);
         rulesScrollPane.setViewportView(rulesTree);
+
+        rulesPanel.add(rulesScrollPane, java.awt.BorderLayout.CENTER);
+
+        rulesButtonsPanel.setLayout(new javax.swing.BoxLayout(rulesButtonsPanel, javax.swing.BoxLayout.LINE_AXIS));
 
         org.openide.awt.Mnemonics.setLocalizedText(addRuleButton, OStrings.getString("BUTTON_ADD_NODOTS")); // NOI18N
         addRuleButton.addActionListener(new java.awt.event.ActionListener() {
@@ -804,6 +751,7 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
                 addRuleButtonActionPerformed(evt);
             }
         });
+        rulesButtonsPanel.add(addRuleButton);
 
         org.openide.awt.Mnemonics.setLocalizedText(deleteRuleButton, OStrings.getString("BUTTON_REMOVE")); // NOI18N
         deleteRuleButton.setToolTipText("");
@@ -812,53 +760,38 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
                 deleteRuleButtonActionPerformed(evt);
             }
         });
+        rulesButtonsPanel.add(deleteRuleButton);
 
-        javax.swing.GroupLayout rulesPanelLayout = new javax.swing.GroupLayout(rulesPanel);
-        rulesPanel.setLayout(rulesPanelLayout);
-        rulesPanelLayout.setHorizontalGroup(
-            rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(rulesScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 598, Short.MAX_VALUE)
-            .addGroup(rulesPanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(addRuleButton)
-                .addGap(18, 18, 18)
-                .addComponent(deleteRuleButton)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-        );
+        rulesPanel.add(rulesButtonsPanel, java.awt.BorderLayout.SOUTH);
 
-        rulesPanelLayout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {addRuleButton, deleteRuleButton});
+        centerPanel.add(rulesPanel, java.awt.BorderLayout.CENTER);
 
-        rulesPanelLayout.setVerticalGroup(
-            rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(rulesPanelLayout.createSequentialGroup()
-                .addComponent(rulesScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 208, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(addRuleButton)
-                    .addComponent(deleteRuleButton)))
-        );
+        getContentPane().add(centerPanel, java.awt.BorderLayout.CENTER);
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(typePanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .addComponent(externalOptionsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .addComponent(bottomPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 610, Short.MAX_VALUE)
-            .addComponent(rulesPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addComponent(typePanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(externalOptionsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 138, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(rulesPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(bottomPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap())
-        );
+        bottomPanel.setPreferredSize(new java.awt.Dimension(631, 40));
+        bottomPanel.setLayout(new java.awt.BorderLayout());
+
+        buttonsPanel.setLayout(new javax.swing.BoxLayout(buttonsPanel, javax.swing.BoxLayout.LINE_AXIS));
+
+        org.openide.awt.Mnemonics.setLocalizedText(cancelButton, OStrings.getString("BUTTON_CANCEL")); // NOI18N
+        cancelButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cancelButtonActionPerformed(evt);
+            }
+        });
+        buttonsPanel.add(cancelButton);
+
+        org.openide.awt.Mnemonics.setLocalizedText(okButton, OStrings.getString("BUTTON_OK")); // NOI18N
+        okButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                okButtonActionPerformed(evt);
+            }
+        });
+        buttonsPanel.add(okButton);
+
+        bottomPanel.add(buttonsPanel, java.awt.BorderLayout.EAST);
+
+        getContentPane().add(bottomPanel, java.awt.BorderLayout.SOUTH);
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -962,16 +895,23 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
     private javax.swing.JRadioButton bridgeNativeRadioButton;
     private javax.swing.JRadioButton bridgeRemoteRadioButton;
     private javax.swing.ButtonGroup buttonGroup1;
+    private javax.swing.JPanel buttonsPanel;
     private javax.swing.JButton cancelButton;
+    private javax.swing.JPanel centerPanel;
     private javax.swing.JButton deleteRuleButton;
     private javax.swing.JButton directoryChooseButton;
+    private javax.swing.JPanel directoryPanel;
     private javax.swing.JTextField directoryTextField;
     private javax.swing.JPanel externalOptionsPanel;
+    private javax.swing.JPanel localPanel;
     private javax.swing.JLabel localPathLabel;
     private javax.swing.JButton okButton;
+    private javax.swing.JPanel remotePanel;
+    private javax.swing.JPanel rulesButtonsPanel;
     private javax.swing.JPanel rulesPanel;
     private javax.swing.JScrollPane rulesScrollPane;
     private javax.swing.JTree rulesTree;
+    private javax.swing.JPanel topPanel;
     private javax.swing.JPanel typePanel;
     private javax.swing.JLabel urlLabel;
     private javax.swing.JTextField urlTextField;

--- a/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
+++ b/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
@@ -318,6 +318,8 @@ class CheckBoxTreeCellRenderer extends JPanel implements TreeCellRenderer {
         setOpaque(false);
         checkBox.setOpaque(false);
         renderer.setLeafIcon(null);
+        renderer.setOpenIcon(null);
+        renderer.setClosedIcon(null);
         add(checkBox, BorderLayout.WEST);
     }
 
@@ -647,8 +649,7 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
         setTitle(OStrings.getString("GUI_LANGUAGETOOL_DIALOG_TITLE")); // NOI18N
         setResizable(false);
 
-        typePanel.setBorder(
-                javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_BRIDGE_TYPE"))); // NOI18N
+        typePanel.setBorder(javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_BRIDGE_TYPE"))); // NOI18N
 
         buttonGroup1.add(bridgeNativeRadioButton);
         bridgeNativeRadioButton.setSelected(true);
@@ -679,24 +680,29 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
 
         javax.swing.GroupLayout typePanelLayout = new javax.swing.GroupLayout(typePanel);
         typePanel.setLayout(typePanelLayout);
-        typePanelLayout
-                .setHorizontalGroup(typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                        .addGroup(typePanelLayout.createSequentialGroup().addContainerGap()
-                                .addComponent(bridgeNativeRadioButton)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                                .addComponent(bridgeRemoteRadioButton)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                                .addComponent(bridgeLocalRadioButton)
-                                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)));
-        typePanelLayout.setVerticalGroup(typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(typePanelLayout.createSequentialGroup().addContainerGap()
-                        .addGroup(typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                                .addComponent(bridgeNativeRadioButton).addComponent(bridgeRemoteRadioButton)
-                                .addComponent(bridgeLocalRadioButton))
-                        .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)));
+        typePanelLayout.setHorizontalGroup(
+            typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(typePanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(bridgeNativeRadioButton)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(bridgeRemoteRadioButton)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(bridgeLocalRadioButton)
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
+        typePanelLayout.setVerticalGroup(
+            typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(typePanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(typePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(bridgeNativeRadioButton)
+                    .addComponent(bridgeRemoteRadioButton)
+                    .addComponent(bridgeLocalRadioButton))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
 
-        externalOptionsPanel.setBorder(
-                javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_EXTERNAL_SETTINGS"))); // NOI18N
+        externalOptionsPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_EXTERNAL_SETTINGS"))); // NOI18N
 
         directoryTextField.setToolTipText("");
 
@@ -715,39 +721,38 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
 
         javax.swing.GroupLayout externalOptionsPanelLayout = new javax.swing.GroupLayout(externalOptionsPanel);
         externalOptionsPanel.setLayout(externalOptionsPanelLayout);
-        externalOptionsPanelLayout.setHorizontalGroup(externalOptionsPanelLayout
-                .createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(externalOptionsPanelLayout.createSequentialGroup().addContainerGap()
-                        .addGroup(externalOptionsPanelLayout
-                                .createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                .addGroup(javax.swing.GroupLayout.Alignment.TRAILING,
-                                        externalOptionsPanelLayout.createSequentialGroup()
-                                                .addComponent(directoryTextField, javax.swing.GroupLayout.DEFAULT_SIZE,
-                                                        454, Short.MAX_VALUE)
-                                                .addGap(18, 18, 18).addComponent(directoryChooseButton))
-                                .addComponent(urlTextField, javax.swing.GroupLayout.Alignment.TRAILING)
-                                .addGroup(externalOptionsPanelLayout.createSequentialGroup()
-                                        .addGroup(externalOptionsPanelLayout
-                                                .createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                                .addComponent(urlLabel).addComponent(localPathLabel))
-                                        .addGap(0, 0, Short.MAX_VALUE)))
-                        .addContainerGap()));
-        externalOptionsPanelLayout.setVerticalGroup(externalOptionsPanelLayout
-                .createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(externalOptionsPanelLayout.createSequentialGroup().addContainerGap().addComponent(urlLabel)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED,
-                                javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(urlTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 24,
-                                javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(localPathLabel)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(externalOptionsPanelLayout
-                                .createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                                .addComponent(directoryTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 24,
-                                        javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(directoryChooseButton))
-                        .addGap(40, 40, 40)));
+        externalOptionsPanelLayout.setHorizontalGroup(
+            externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(externalOptionsPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, externalOptionsPanelLayout.createSequentialGroup()
+                        .addComponent(directoryTextField, javax.swing.GroupLayout.DEFAULT_SIZE, 454, Short.MAX_VALUE)
+                        .addGap(18, 18, 18)
+                        .addComponent(directoryChooseButton))
+                    .addComponent(urlTextField, javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addGroup(externalOptionsPanelLayout.createSequentialGroup()
+                        .addGroup(externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(urlLabel)
+                            .addComponent(localPathLabel))
+                        .addGap(0, 0, Short.MAX_VALUE)))
+                .addContainerGap())
+        );
+        externalOptionsPanelLayout.setVerticalGroup(
+            externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(externalOptionsPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(urlLabel)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(urlTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 24, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(localPathLabel)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(externalOptionsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(directoryTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 24, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(directoryChooseButton))
+                .addGap(40, 40, 40))
+        );
 
         bottomPanel.setPreferredSize(new java.awt.Dimension(631, 40));
 
@@ -782,7 +787,7 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
         bottomPanelLayout.setVerticalGroup(
             bottomPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(bottomPanelLayout.createSequentialGroup()
-                .addContainerGap(15, Short.MAX_VALUE)
+                .addContainerGap(11, Short.MAX_VALUE)
                 .addGroup(bottomPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(cancelButton)
                     .addComponent(okButton)))
@@ -790,6 +795,7 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
 
         rulesPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(OStrings.getString("GUI_LANGUAGETOOL_RULES"))); // NOI18N
 
+        rulesTree.setShowsRootHandles(true);
         rulesScrollPane.setViewportView(rulesTree);
 
         org.openide.awt.Mnemonics.setLocalizedText(addRuleButton, OStrings.getString("BUTTON_ADD_NODOTS")); // NOI18N
@@ -809,52 +815,50 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
 
         javax.swing.GroupLayout rulesPanelLayout = new javax.swing.GroupLayout(rulesPanel);
         rulesPanel.setLayout(rulesPanelLayout);
-        rulesPanelLayout
-                .setHorizontalGroup(rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                        .addComponent(rulesScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 598, Short.MAX_VALUE)
-                        .addGroup(rulesPanelLayout.createSequentialGroup().addContainerGap().addComponent(addRuleButton)
-                                .addGap(18, 18, 18).addComponent(deleteRuleButton).addContainerGap(
-                                        javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)));
+        rulesPanelLayout.setHorizontalGroup(
+            rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(rulesScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 598, Short.MAX_VALUE)
+            .addGroup(rulesPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(addRuleButton)
+                .addGap(18, 18, 18)
+                .addComponent(deleteRuleButton)
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
 
-        rulesPanelLayout.linkSize(javax.swing.SwingConstants.HORIZONTAL,
-                new java.awt.Component[] { addRuleButton, deleteRuleButton });
+        rulesPanelLayout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {addRuleButton, deleteRuleButton});
 
-        rulesPanelLayout
-                .setVerticalGroup(
-                        rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                .addGroup(rulesPanelLayout.createSequentialGroup()
-                                        .addComponent(rulesScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 208,
-                                                javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addGroup(rulesPanelLayout
-                                                .createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                                                .addComponent(addRuleButton).addComponent(deleteRuleButton))));
+        rulesPanelLayout.setVerticalGroup(
+            rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(rulesPanelLayout.createSequentialGroup()
+                .addComponent(rulesScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 208, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(rulesPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(addRuleButton)
+                    .addComponent(deleteRuleButton)))
+        );
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addComponent(typePanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE,
-                        Short.MAX_VALUE)
-                .addComponent(externalOptionsPanel, javax.swing.GroupLayout.DEFAULT_SIZE,
-                        javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(bottomPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 608, Short.MAX_VALUE)
-                .addComponent(rulesPanel, javax.swing.GroupLayout.Alignment.TRAILING,
-                        javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE));
-        layout.setVerticalGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(layout.createSequentialGroup()
-                        .addComponent(typePanel, javax.swing.GroupLayout.PREFERRED_SIZE,
-                                javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(externalOptionsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 138,
-                                javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(rulesPanel, javax.swing.GroupLayout.PREFERRED_SIZE,
-                                javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED,
-                                javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(bottomPanel, javax.swing.GroupLayout.PREFERRED_SIZE,
-                                javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addContainerGap()));
+        layout.setHorizontalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(typePanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(externalOptionsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(bottomPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 610, Short.MAX_VALUE)
+            .addComponent(rulesPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+        );
+        layout.setVerticalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(layout.createSequentialGroup()
+                .addComponent(typePanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(externalOptionsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 138, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(rulesPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(bottomPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap())
+        );
 
         pack();
     }// </editor-fold>//GEN-END:initComponents

--- a/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
+++ b/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
@@ -62,7 +62,6 @@ import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreePath;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.jetbrains.annotations.NotNull;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
@@ -529,7 +528,6 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
         return ret;
     }
 
-    @NotNull
     private DefaultTreeModel getTreeModel(DefaultMutableTreeNode rootNode) {
         DefaultTreeModel treeModel = new DefaultTreeModel(rootNode);
         treeModel.addTreeModelListener(new TreeModelListener() {

--- a/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
+++ b/src/org/omegat/gui/dialogs/LanguageToolConfigurationDialog.java
@@ -380,15 +380,16 @@ public class LanguageToolConfigurationDialog extends javax.swing.JDialog {
         // Load rule tree
         Optional<org.languagetool.Language> targetLtLang = getLTLanguage(targetLang);
         Optional<org.languagetool.Language> sourceLtLang = getLTLanguage(sourceLang);
-
-        // Disable tree and return if targetLang wasn't found
-        if (!targetLtLang.isPresent()) {
+        JLanguageTool ltInstance;
+        try {
+            ltInstance = new JLanguageTool(targetLtLang.get());
+        } catch (Throwable e) {
+            // Disable tree and return if instance couldn't be gotten
             ((DefaultTreeModel) rulesTree.getModel()).setRoot(null);
             rulesTree.setEnabled(false);
             return;
         }
 
-        JLanguageTool ltInstance = new JLanguageTool(targetLtLang.get());
         List<Rule> rules = ltInstance.getAllRules();
         sourceLtLang.ifPresent(srcLtLang -> {
             try {

--- a/src/org/omegat/gui/dialogs/NewTeamProject.java
+++ b/src/org/omegat/gui/dialogs/NewTeamProject.java
@@ -187,7 +187,7 @@ public class NewTeamProject extends javax.swing.JDialog {
         updateDialog();
     }
 
-    private class RepoTypeWorker extends SwingWorker<String, Object> {
+    private class RepoTypeWorker extends SwingWorker<String, Void> {
 
         private final String url;
 

--- a/src/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -402,7 +402,8 @@ public class ProjectFilesListController {
             // Otherwise use the clicked row
             rows = new int[] { row };
         }
-        List<FileInfo> infos = IntStream.of(rows).mapToObj(r -> modelFiles.getDataAtRow(r))
+        List<FileInfo> infos = IntStream.of(rows).map(list.tableFiles.getRowSorter()::convertRowIndexToModel)
+                .mapToObj(modelFiles::getDataAtRow)
                 .collect(Collectors.toList());
         if (infos.isEmpty() || infos.stream().anyMatch(Objects::isNull)) {
             return null;

--- a/src/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -58,6 +58,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -403,7 +404,7 @@ public class ProjectFilesListController {
         }
         List<FileInfo> infos = IntStream.of(rows).mapToObj(r -> modelFiles.getDataAtRow(r))
                 .collect(Collectors.toList());
-        if (infos.isEmpty() || infos.stream().anyMatch(i -> i == null)) {
+        if (infos.isEmpty() || infos.stream().anyMatch(Objects::isNull)) {
             return null;
         }
         String sourceDir = Core.getProject().getProjectProperties().getSourceRoot();
@@ -430,24 +431,21 @@ public class ProjectFilesListController {
             modTitle = OStrings.getString(isSource ? "PF_REVEAL_SOURCE_FILE" : "PF_REVEAL_TARGET_FILE");
         }
         JMenuItem item = menu.add(defaultTitle);
-        item.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                boolean openParent = (e.getModifiers() & Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()) != 0;
-                Stream<File> stream;
-                if (openParent) {
-                    stream = files.stream().map(File::getParentFile).distinct().filter(File::isDirectory);
-                } else {
-                    stream = files.stream().filter(File::isFile);
-                }
-                stream.forEach(f -> {
-                    try {
-                        Desktop.getDesktop().open(f);
-                    } catch (IOException ex) {
-                        Log.log(ex);
-                    }
-                });
+        item.addActionListener(e -> {
+            boolean openParent = (e.getModifiers() & Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()) != 0;
+            Stream<File> stream;
+            if (openParent) {
+                stream = files.stream().map(File::getParentFile).distinct().filter(File::isDirectory);
+            } else {
+                stream = files.stream().filter(File::isFile);
             }
+            stream.forEach(f -> {
+                try {
+                    Desktop.getDesktop().open(f);
+                } catch (IOException ex) {
+                    Log.log(ex);
+                }
+            });
         });
         item.setEnabled(presentFiles > 0);
         item.addMenuKeyListener(new MenuKeyListener() {

--- a/src/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -96,7 +96,6 @@ import org.omegat.core.CoreEvents;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.FileInfo;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.core.events.IFontChangedEventListener;
 import org.omegat.core.events.IProjectEventListener;
@@ -294,17 +293,6 @@ public class ProjectFilesListController {
                     newFont = defaultFont;
                 }
                 setFont(newFont);
-            }
-        });
-
-        CoreEvents.registerApplicationEventListener(new IApplicationEventListener() {
-            @Override
-            public void onApplicationStartup() {
-            }
-
-            @Override
-            public void onApplicationShutdown() {
-                saveWindowLayout();
             }
         });
 
@@ -683,33 +671,10 @@ public class ProjectFilesListController {
      * Loads/sets the position and size of the project files window.
      */
     private void initWindowLayout() {
-        // main window
-        try {
-            String dx = Preferences.getPreference(Preferences.PROJECT_FILES_WINDOW_X);
-            String dy = Preferences.getPreference(Preferences.PROJECT_FILES_WINDOW_Y);
-            int x = Integer.parseInt(dx);
-            int y = Integer.parseInt(dy);
-            list.setLocation(x, y);
-            String dw = Preferences.getPreference(Preferences.PROJECT_FILES_WINDOW_WIDTH);
-            String dh = Preferences.getPreference(Preferences.PROJECT_FILES_WINDOW_HEIGHT);
-            int w = Integer.parseInt(dw);
-            int h = Integer.parseInt(dh);
-            list.setSize(w, h);
-        } catch (NumberFormatException nfe) {
-            // set default size and position
-            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-            list.setBounds((screenSize.width - 640) / 2, (screenSize.height - 400) / 2, 640, 400);
-        }
-    }
-
-    /**
-     * Saves the size and position of the project files window
-     */
-    private void saveWindowLayout() {
-        Preferences.setPreference(Preferences.PROJECT_FILES_WINDOW_WIDTH, list.getWidth());
-        Preferences.setPreference(Preferences.PROJECT_FILES_WINDOW_HEIGHT, list.getHeight());
-        Preferences.setPreference(Preferences.PROJECT_FILES_WINDOW_X, list.getX());
-        Preferences.setPreference(Preferences.PROJECT_FILES_WINDOW_Y, list.getY());
+        // set default size and position
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        list.setBounds((screenSize.width - 640) / 2, (screenSize.height - 400) / 2, 640, 400);
+        StaticUIUtils.persistGeometry(list, Preferences.PROJECT_FILES_WINDOW_GEOMETRY_PREFIX);
     }
 
     private void doCancel() {

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -40,6 +40,7 @@ import java.awt.KeyboardFocusManager;
 import java.awt.Toolkit;
 import java.io.File;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingWorker;
@@ -208,7 +209,7 @@ public class MainWindowMenuHandler {
             return;
         }
 
-        String sourcePattern = StaticUtils.escapeNonRegex(midName);
+        String sourcePattern = Pattern.quote(midName);
         if (Preferences.isPreference(Preferences.TAGS_VALID_REQUIRED)) {
             List<ErrorReport> stes = Core.getTagValidation().listInvalidTags(sourcePattern);
             if (stes != null) {
@@ -782,7 +783,7 @@ public class MainWindowMenuHandler {
         String midName = Core.getEditor().getCurrentFile();
         List<ErrorReport> stes = null;
         if (!StringUtil.isEmpty(midName)) {
-            String sourcePattern = StaticUtils.escapeNonRegex(midName);
+            String sourcePattern = Pattern.quote(midName);
             stes = Core.getTagValidation().listInvalidTags(sourcePattern);
         }
         Core.getTagValidation().displayTagValidationErrors(stes, null);

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -1030,7 +1030,9 @@ public class MainWindowMenuHandler {
      * Opens the LanguageTool window
      */
     public void optionsLanguageToolMenuItemActionPerformed() {
-        LanguageToolConfigurationDialog ld = new LanguageToolConfigurationDialog(mainWindow, true);
+        LanguageToolConfigurationDialog ld = new LanguageToolConfigurationDialog(mainWindow, true,
+                Core.getProject().getProjectProperties().getSourceLanguage(),
+                Core.getProject().getProjectProperties().getTargetLanguage());
 
         ld.setVisible(true);
     }

--- a/src/org/omegat/gui/main/MainWindowUI.java
+++ b/src/org/omegat/gui/main/MainWindowUI.java
@@ -254,43 +254,32 @@ public class MainWindowUI {
 
     /**
      * Initialize the size of OmegaT window, then load the layout prefs.
-     * <p>
-     * Assume screen size is 800x600 if width less than 900, and 1024x768 if
-     * larger. Assume task bar at bottom of screen. If screen size saved,
-     * recover that and use instead (18may04).
      */
     public static void initializeScreenLayout(MainWindow mainWindow) {
-        int x, y, w, h;
-        // main window
-        try {
-            x = Integer.parseInt(Preferences.getPreference(Preferences.MAINWINDOW_X));
-            y = Integer.parseInt(Preferences.getPreference(Preferences.MAINWINDOW_Y));
-            w = Integer.parseInt(Preferences.getPreference(Preferences.MAINWINDOW_WIDTH));
-            h = Integer.parseInt(Preferences.getPreference(Preferences.MAINWINDOW_HEIGHT));
-        } catch (NumberFormatException nfe) {
-            // size info missing - put window in default position
-            GraphicsEnvironment env = GraphicsEnvironment.getLocalGraphicsEnvironment();
-            Rectangle scrSize = env.getMaximumWindowBounds();
-            if (scrSize.width < 900) {
-                // assume 800x600
-                x = 0;
-                y = 0;
-                w = 580;
-                h = 536;
-            } else {
-                // assume 1024x768 or larger
-                x = 0;
-                y = 0;
-                w = 690;
-                h = 700;
-            }
-        }
-        w = StaticUIUtils.correctFrameWidth(w);
-        mainWindow.setBounds(x, y, w, h);
+        mainWindow.setBounds(getDefaultBounds());
+        StaticUIUtils.persistGeometry(mainWindow, Preferences.MAINWINDOW_GEOMETRY_PREFIX);
 
         loadScreenLayoutFromPreferences(mainWindow);
     }
     
+    /**
+     * Assume screen size is 800x600 if width less than 900, and 1024x768 if
+     * larger. Assume task bar at bottom of screen. If screen size saved,
+     * recover that and use instead (18may04).
+     */
+    static Rectangle getDefaultBounds() {
+        // size info missing - put window in default position
+        GraphicsEnvironment env = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        Rectangle scrSize = env.getMaximumWindowBounds();
+        if (scrSize.width < 900) {
+            // assume 800x600
+            return new Rectangle(0, 0, 580, 536);
+        } else {
+            // assume 1024x768 or larger
+            return new Rectangle(0, 0, 690, 700);
+        }
+    }
+
     /**
      * Load the main window layout from the global preferences file. Will reset to defaults
      * if global preferences are not present or if an error occurs.
@@ -318,7 +307,7 @@ public class MainWindowUI {
     }
 
     /**
-     * Stores main window layout (width, height, position, etc.) to global preferences.
+     * Stores main window docking layout to disk.
      */
     public static void saveScreenLayout(MainWindow mainWindow) {
         File uiLayoutFile = new File(StaticUtils.getConfigDir(), MainWindowUI.UI_LAYOUT_FILE);
@@ -329,11 +318,6 @@ public class MainWindowUI {
      * Stores main window layout to the specified output file.
      */
     private static void saveScreenLayout(MainWindow mainWindow, File uiLayoutFile) {
-        Preferences.setPreference(Preferences.MAINWINDOW_X, mainWindow.getX());
-        Preferences.setPreference(Preferences.MAINWINDOW_Y, mainWindow.getY());
-        Preferences.setPreference(Preferences.MAINWINDOW_WIDTH, mainWindow.getWidth());
-        Preferences.setPreference(Preferences.MAINWINDOW_HEIGHT, mainWindow.getHeight());
-
         try (OutputStream out = new FileOutputStream(uiLayoutFile)) {
             mainWindow.desktop.writeXML(out);
         } catch (Exception ex) {

--- a/src/org/omegat/gui/scripting/RichScriptEditor.java
+++ b/src/org/omegat/gui/scripting/RichScriptEditor.java
@@ -97,8 +97,8 @@ public class RichScriptEditor extends AbstractScriptEditor implements SearchList
 
     public void initSearchDialogs() {
 
-        m_findDialog = new FindDialog(m_scriptingWindow, this);
-        m_replaceDialog = new ReplaceDialog(m_scriptingWindow, this);
+        m_findDialog = new FindDialog(m_scriptingWindow.frame, this);
+        m_replaceDialog = new ReplaceDialog(m_scriptingWindow.frame, this);
 
         // This ties the properties of the two dialogs together (match case, regex, etc.).
         SearchContext context = m_findDialog.getSearchContext();
@@ -159,7 +159,7 @@ public class RichScriptEditor extends AbstractScriptEditor implements SearchList
             if (m_replaceDialog.isVisible()) {
                 m_replaceDialog.setVisible(false);
             }
-            GoToDialog dialog = new GoToDialog(m_scriptingWindow);
+            GoToDialog dialog = new GoToDialog(m_scriptingWindow.frame);
             dialog.setMaxLineNumberAllowed(m_scriptEditor.getLineCount());
             dialog.setVisible(true);
             int line = dialog.getLineNumber();
@@ -234,7 +234,7 @@ public class RichScriptEditor extends AbstractScriptEditor implements SearchList
         RTextScrollPane scrollPaneEditor = new RTextScrollPane(m_scriptEditor);
         // scrollPaneEditor.setMinimumSize(minimumSize1);
         m_csp = new CollapsibleSectionPanel();
-        m_scriptingWindow.getContentPane().add(m_csp);
+        m_scriptingWindow.frame.getContentPane().add(m_csp);
         m_csp.add(scrollPaneEditor);
 
         initSearchDialogs();

--- a/src/org/omegat/gui/scripting/ScriptingWindow.java
+++ b/src/org/omegat/gui/scripting/ScriptingWindow.java
@@ -128,7 +128,6 @@ public class ScriptingWindow extends JFrame {
 
     @Override
     public void dispose() {
-        savePreferences();
         monitor.stop();
         super.dispose();
     }
@@ -299,7 +298,10 @@ public class ScriptingWindow extends JFrame {
     }
 
     private void initWindowLayout() {
-        loadPreferences();
+        // set default size and position
+        setBounds(50, 80, 1150, 650);
+        StaticUIUtils.persistGeometry(this, Preferences.SCRIPTWINDOW_GEOMETRY_PREFIX);
+
         getContentPane().setLayout(new BorderLayout(0, 0));
 
         m_scriptList = new JList<>();
@@ -708,39 +710,6 @@ public class ScriptingWindow extends JFrame {
 
     void setScriptItems(Collection<ScriptItem> items) {
         m_scriptList.setListData(items.toArray(new ScriptItem[items.size()]));
-    }
-
-    /**
-     * Loads the position and size of the script window
-     */
-    private void loadPreferences() {
-        // window size and position
-        try {
-            String dx = Preferences.getPreference(Preferences.SCRIPTWINDOW_X);
-            String dy = Preferences.getPreference(Preferences.SCRIPTWINDOW_Y);
-            int x = Integer.parseInt(dx);
-            int y = Integer.parseInt(dy);
-            setLocation(x, y);
-            String dw = Preferences.getPreference(Preferences.SCRIPTWINDOW_WIDTH);
-            String dh = Preferences.getPreference(Preferences.SCRIPTWINDOW_HEIGHT);
-            int w = Integer.parseInt(dw);
-            int h = Integer.parseInt(dh);
-            setSize(w, h);
-        } catch (NumberFormatException nfe) {
-            // set default size and position
-            setBounds(50, 80, 1150, 650);
-        }
-    }
-
-    /**
-     * Saves the size and position of the script window
-     */
-    private void savePreferences() {
-        // window size and position
-        Preferences.setPreference(Preferences.SCRIPTWINDOW_WIDTH, getWidth());
-        Preferences.setPreference(Preferences.SCRIPTWINDOW_HEIGHT, getHeight());
-        Preferences.setPreference(Preferences.SCRIPTWINDOW_X, getX());
-        Preferences.setPreference(Preferences.SCRIPTWINDOW_Y, getY());
     }
 
     private void onListSelectionChanged() {

--- a/src/org/omegat/gui/scripting/ScriptingWindow.java
+++ b/src/org/omegat/gui/scripting/ScriptingWindow.java
@@ -532,7 +532,7 @@ public class ScriptingWindow extends JFrame {
         executeScript(scriptString, m_currentScriptItem);
     }
 
-    private class ScriptWorker extends SwingWorker<String, Object> {
+    private class ScriptWorker extends SwingWorker<String, Void> {
 
         private final String scriptString;
         private final ScriptItem scriptItem;

--- a/src/org/omegat/gui/search/EntryListPane.java
+++ b/src/org/omegat/gui/search/EntryListPane.java
@@ -293,7 +293,7 @@ class EntryListPane extends JTextPane {
             }
 
             if (!matches.isEmpty()) {
-                SwingUtilities.invokeLater(() -> doMarks());
+                SwingUtilities.invokeLater(this::doMarks);
             }
         }
 
@@ -370,7 +370,7 @@ class EntryListPane extends JTextPane {
             display.clear();
 
             if (!matches.isEmpty()) {
-                SwingUtilities.invokeLater(() -> doMarks());
+                SwingUtilities.invokeLater(this::doMarks);
             }
         }
     }

--- a/src/org/omegat/gui/search/EntryListPane.java
+++ b/src/org/omegat/gui/search/EntryListPane.java
@@ -157,7 +157,7 @@ class EntryListPane extends JTextPane {
                         getActiveDisplayedEntry().gotoEntryInEditor();
                     }
                     JFrame frame = Core.getMainWindow().getApplicationFrame();
-                    frame.setState(JFrame.NORMAL);
+                    frame.setExtendedState(JFrame.NORMAL);
                     frame.toFront();
                 }
             }

--- a/src/org/omegat/gui/search/SearchWindowController.java
+++ b/src/org/omegat/gui/search/SearchWindowController.java
@@ -922,7 +922,7 @@ public class SearchWindowController {
             ((JTextField) form.m_searchField.getEditor().getEditorComponent()).setText(query);
         }
         form.setVisible(true);
-        form.setState(JFrame.NORMAL);
+        form.setExtendedState(JFrame.NORMAL);
         form.m_searchField.requestFocus();
     }
 

--- a/src/org/omegat/gui/search/SearchWindowController.java
+++ b/src/org/omegat/gui/search/SearchWindowController.java
@@ -450,22 +450,9 @@ public class SearchWindowController {
      * state.
      */
     private void loadPreferences() {
-        // window size and position
-        try {
-            String dx = Preferences.getPreference(Preferences.SEARCHWINDOW_X);
-            String dy = Preferences.getPreference(Preferences.SEARCHWINDOW_Y);
-            int x = Integer.parseInt(dx);
-            int y = Integer.parseInt(dy);
-            form.setLocation(x, y);
-            String dw = Preferences.getPreference(Preferences.SEARCHWINDOW_WIDTH);
-            String dh = Preferences.getPreference(Preferences.SEARCHWINDOW_HEIGHT);
-            int w = StaticUIUtils.correctFrameWidth(Integer.parseInt(dw));
-            int h = Integer.parseInt(dh);
-            form.setSize(w, h);
-        } catch (NumberFormatException nfe) {
-            // set default size and position
-            form.setSize(800, 700);
-        }
+        // set default size and position
+        form.setSize(800, 700);
+        StaticUIUtils.persistGeometry(form, Preferences.SEARCHWINDOW_GEOMETRY_PREFIX);
 
         // search dir options
         if (Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_SEARCH_FILES, false)) {
@@ -578,12 +565,6 @@ public class SearchWindowController {
      * state
      */
     private void savePreferences() {
-        // window size and position
-        Preferences.setPreference(Preferences.SEARCHWINDOW_WIDTH, form.getWidth());
-        Preferences.setPreference(Preferences.SEARCHWINDOW_HEIGHT, form.getHeight());
-        Preferences.setPreference(Preferences.SEARCHWINDOW_X, form.getX());
-        Preferences.setPreference(Preferences.SEARCHWINDOW_Y, form.getY());
-
         // search type
         if (form.m_searchExactSearchRB.isSelected()) {
             Preferences.setPreference(Preferences.SEARCHWINDOW_SEARCH_TYPE,

--- a/src/org/omegat/gui/tagvalidation/TagValidationTool.java
+++ b/src/org/omegat/gui/tagvalidation/TagValidationTool.java
@@ -220,7 +220,7 @@ public class TagValidationTool implements ITagValidation, IProjectEventListener 
         if (!te.isTranslated() || s.isEmpty()) {
             return null;
         }
-        ErrorReport report = new ErrorReport(ste, te.translation);
+        ErrorReport report = new ErrorReport(ste, te);
 
         // Check printf variables
         if (Preferences.isPreference(Preferences.CHECK_ALL_PRINTF_TAGS)) {

--- a/src/org/omegat/gui/tagvalidation/TagValidationTool.java
+++ b/src/org/omegat/gui/tagvalidation/TagValidationTool.java
@@ -32,9 +32,9 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import javax.swing.JOptionPane;
 
@@ -260,23 +260,12 @@ public class TagValidationTool implements ITagValidation, IProjectEventListener 
             return null;
         }
 
-        // Sort the map first to ensure that fixing works properly.
-        Map<Tag, TagError> sortedErrors = new TreeMap<Tag, TagError>(new Comparator<Tag>() {
-            @Override
-            public int compare(Tag o1, Tag o2) {
-                return o1.pos < o2.pos ? -1
-                        : o1.pos > o2.pos ? 1
-                        : 0;
-            }
-        });
-        sortedErrors.putAll(report.srcErrors);
-        sortedErrors.putAll(report.transErrors);
-
         StringBuilder sb = new StringBuilder(report.translation);
 
-        for (Map.Entry<Tag, TagError> e : sortedErrors.entrySet()) {
-            TagRepair.fixTag(report.ste, e.getKey(), e.getValue(), sb, report.source);
-        }
+        Stream.of(report.srcErrors, report.transErrors).flatMap(m -> m.entrySet().stream())
+                .sorted(Comparator.comparing(e -> e.getKey().pos)).forEach(e -> {
+                    TagRepair.fixTag(report.ste, e.getKey(), e.getValue(), sb, report.source);
+                });
 
         return sb.toString();
     }

--- a/src/org/omegat/languagetools/LanguageToolNativeBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNativeBridge.java
@@ -26,12 +26,12 @@
  **************************************************************************/
 package org.omegat.languagetools;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
@@ -76,10 +76,9 @@ public class LanguageToolNativeBridge implements ILanguageToolBridge {
         if (targetLt == null) {
             return;
         }
-        Set<CategoryId> dc = Arrays.asList(disabledCategories.split(",")).stream().
-                map(p -> new CategoryId(p)).collect(Collectors.toSet());
-        Set<String> dr = Arrays.asList(disabledRules.split(",")).stream().collect(Collectors.toSet());
-        Set<String> er = Arrays.asList(enabledRules.split(",")).stream().collect(Collectors.toSet());
+        Set<CategoryId> dc = Stream.of(disabledCategories.split(",")).map(CategoryId::new).collect(Collectors.toSet());
+        Set<String> dr = Stream.of(disabledRules.split(",")).collect(Collectors.toSet());
+        Set<String> er = Stream.of(enabledRules.split(",")).collect(Collectors.toSet());
         Tools.selectRules(targetLt.get(), dc, Collections.emptySet(), dr, er, false);
         if (bRules != null) {
             bRules = bRules.stream().filter(rule -> !dr.contains(rule.getId())).collect(Collectors.toList());

--- a/src/org/omegat/languagetools/LanguageToolNativeBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNativeBridge.java
@@ -28,7 +28,6 @@ package org.omegat.languagetools;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -81,7 +80,7 @@ public class LanguageToolNativeBridge implements ILanguageToolBridge {
                 map(p -> new CategoryId(p)).collect(Collectors.toSet());
         Set<String> dr = Arrays.asList(disabledRules.split(",")).stream().collect(Collectors.toSet());
         Set<String> er = Arrays.asList(enabledRules.split(",")).stream().collect(Collectors.toSet());
-        Tools.selectRules(targetLt.get(), dc, new HashSet<>(), dr, er, false);
+        Tools.selectRules(targetLt.get(), dc, Collections.emptySet(), dr, er, false);
         if (bRules != null) {
             bRules = bRules.stream().filter(rule -> !dr.contains(rule.getId())).collect(Collectors.toList());
         }

--- a/src/org/omegat/languagetools/LanguageToolNativeBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNativeBridge.java
@@ -73,13 +73,14 @@ public class LanguageToolNativeBridge implements ILanguageToolBridge {
 
     @Override
     public void applyRuleFilters(String disabledCategories, String disabledRules, String enabledRules) {
-        if (targetLt == null) {
+        JLanguageTool ltTarget = targetLt.get();
+        if (ltTarget == null) {
             return;
         }
         Set<CategoryId> dc = Stream.of(disabledCategories.split(",")).map(CategoryId::new).collect(Collectors.toSet());
         Set<String> dr = Stream.of(disabledRules.split(",")).collect(Collectors.toSet());
         Set<String> er = Stream.of(enabledRules.split(",")).collect(Collectors.toSet());
-        Tools.selectRules(targetLt.get(), dc, Collections.emptySet(), dr, er, false);
+        Tools.selectRules(ltTarget, dc, Collections.emptySet(), dr, er, false);
         if (bRules != null) {
             bRules = bRules.stream().filter(rule -> !dr.contains(rule.getId())).collect(Collectors.toList());
         }

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -78,6 +78,18 @@ public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApp
     }
 
     /**
+     * Set this instance's LanguageTool bridge based on the current project.
+     */
+    void setBridgeFromCurrentProject() {
+        if (bridge != null) {
+            bridge.stop();
+        }
+        Language sourceLang = Core.getProject().getProjectProperties().getSourceLanguage();
+        Language targetLang = Core.getProject().getProjectProperties().getTargetLanguage();
+        bridge = createBridgeFromPrefs(sourceLang, targetLang);
+    }
+
+    /**
      * Create LanguageTool bridge based on user preferences. Falls back to
      * {@link BridgeType#NATIVE} if non-native bridges fail to initialize (bad
      * config, etc.).
@@ -139,9 +151,7 @@ public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApp
         switch (eventType) {
         case CREATE:
         case LOAD:
-            Language sourceLang = Core.getProject().getProjectProperties().getSourceLanguage();
-            Language targetLang = Core.getProject().getProjectProperties().getTargetLanguage();
-            bridge = createBridgeFromPrefs(sourceLang, targetLang);
+            setBridgeFromCurrentProject();
             break;
         case CLOSE:
             bridge.stop();
@@ -190,10 +200,7 @@ public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApp
         // This property is changed in the end of configuration dialog saving,
         // so at this point every other related properties are already changed.
         if (evt.getPropertyName().equals(Preferences.LANGUAGETOOL_BRIDGE_TYPE)) {
-            bridge.stop();
-            Language sourceLang = Core.getProject().getProjectProperties().getSourceLanguage();
-            Language targetLang = Core.getProject().getProjectProperties().getTargetLanguage();
-            bridge = createBridgeFromPrefs(sourceLang, targetLang);
+            setBridgeFromCurrentProject();
         }
     }
 }

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -121,7 +121,9 @@ public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApp
 
     @Override
     public synchronized void onApplicationShutdown() {
-        bridge.stop();
+        if (bridge != null) {
+            bridge.stop();
+        }
     }
 
     @Override
@@ -143,6 +145,7 @@ public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApp
             break;
         case CLOSE:
             bridge.stop();
+            bridge = null;
             break;
         default:
             // Nothing

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -68,6 +68,9 @@ public class LanguageToolWrapper {
 
     private static volatile ILanguageToolBridge BRIDGE;
 
+    private LanguageToolWrapper() {
+    }
+
     public static void init() {
 
         Core.registerMarker(new LanguageToolMarker());

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -27,8 +27,6 @@
 
 package org.omegat.languagetools;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.List;
 
 import javax.swing.text.Highlighter.HighlightPainter;
@@ -37,7 +35,6 @@ import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.events.IApplicationEventListener;
-import org.omegat.core.events.IProjectEventListener;
 import org.omegat.gui.editor.UnderlineFactory;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
@@ -58,7 +55,7 @@ import org.omegat.util.gui.Styles;
  * @author Aaron Madlon-Kay
  * @author Lev Abashkin
  */
-public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApplicationEventListener, PropertyChangeListener {
+public class LanguageToolWrapper {
     static final HighlightPainter PAINTER = new UnderlineFactory.WaveUnderline(
             Styles.EditorColor.COLOR_LANGUAGE_TOOLS.getColor());
 
@@ -69,24 +66,101 @@ public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApp
         NATIVE, REMOTE_URL, LOCAL_INSTALLATION
     }
 
-    private ILanguageToolBridge bridge;
+    private static volatile ILanguageToolBridge BRIDGE;
 
-    public LanguageToolWrapper() throws Exception {
-        CoreEvents.registerProjectChangeListener(this);
-        CoreEvents.registerApplicationEventListener(this);
-        Preferences.addPropertyChangeListener(this);
+    public static void init() {
+
+        Core.registerMarker(new LanguageToolMarker());
+        
+        CoreEvents.registerProjectChangeListener(e -> {
+            switch (e) {
+                case CREATE:
+                case LOAD:
+                    setBridgeFromCurrentProject();
+                    break;
+                case CLOSE:
+                    BRIDGE.stop();
+                    BRIDGE = null;
+                    break;
+                default:
+                    // Nothing
+                }
+        });
+
+        CoreEvents.registerApplicationEventListener(new IApplicationEventListener() {
+            @Override
+            public synchronized void onApplicationShutdown() {
+                if (BRIDGE != null) {
+                    BRIDGE.stop();
+                }
+            }
+
+            @Override
+            public synchronized void onApplicationStartup() {
+            }
+        });
+
+        Preferences.addPropertyChangeListener(evt -> {
+            if (!Core.getProject().isProjectLoaded()) {
+                return;
+            }
+            // This property is changed in the end of configuration dialog
+            // saving, so at this point every other related properties are
+            // already changed.
+            if (evt.getPropertyName().equals(Preferences.LANGUAGETOOL_BRIDGE_TYPE)) {
+                setBridgeFromCurrentProject();
+            }
+        });
+    }
+
+    static class LanguageToolMarker implements IMarker {
+        @Override
+        public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,
+                boolean isActive) throws Exception {
+
+            if (translationText == null || !isEnabled()) {
+                // Return when disabled or translation text is empty
+                return null;
+            }
+
+            // LanguageTool claims to expect text in NFKC, but that actually
+            // causes problems for some rules:
+            // https://github.com/languagetool-org/languagetool/issues/379
+            // From the discussion it seems the intent behind NFKC was to break
+            // up multi-letter codepoints such as U+FB00 LATIN SMALL LIGATURE
+            // FF. These are unlikely to be found in user input in our case, so
+            // instead we will use NFC. We already normalize our source to NFC
+            // when loading, so we only need to handle the translation here:
+            translationText = StringUtil.normalizeUnicode(translationText);
+
+            // sourceText represents the displayed source text: it may be null
+            // (not displayed) or have extra bidi characters for display. Since
+            // we need it for linguistic comparison here, if it's null then we
+            // pull from the SourceTextEntry, which is guaranteed not to be
+            // null. It doesn't need to be normalized because OmegaT normalizes
+            // all source text to NFC on load.
+            if (sourceText == null) {
+                sourceText = ste.getSrcText();
+            }
+
+            return BRIDGE.getMarksForEntry(ste, sourceText, translationText);
+        }
+
+        protected boolean isEnabled() {
+            return Core.getEditor().getSettings().isMarkLanguageChecker();
+        }
     }
 
     /**
      * Set this instance's LanguageTool bridge based on the current project.
      */
-    void setBridgeFromCurrentProject() {
-        if (bridge != null) {
-            bridge.stop();
+    static void setBridgeFromCurrentProject() {
+        if (BRIDGE != null) {
+            BRIDGE.stop();
         }
         Language sourceLang = Core.getProject().getProjectProperties().getSourceLanguage();
         Language targetLang = Core.getProject().getProjectProperties().getTargetLanguage();
-        bridge = createBridgeFromPrefs(sourceLang, targetLang);
+        BRIDGE = createBridgeFromPrefs(sourceLang, targetLang);
     }
 
     /**
@@ -129,78 +203,5 @@ public class LanguageToolWrapper implements IMarker, IProjectEventListener, IApp
 
         bridge.applyRuleFilters(disabledCategories, disabledRules, enabledRules);
         return bridge;
-    }
-
-    @Override
-    public synchronized void onApplicationShutdown() {
-        if (bridge != null) {
-            bridge.stop();
-        }
-    }
-
-    @Override
-    public synchronized void onApplicationStartup() {
-    }
-
-    public boolean isEnabled() {
-        return Core.getEditor().getSettings().isMarkLanguageChecker();
-    }
-
-    @Override
-    public synchronized void onProjectChanged(PROJECT_CHANGE_TYPE eventType) {
-        switch (eventType) {
-        case CREATE:
-        case LOAD:
-            setBridgeFromCurrentProject();
-            break;
-        case CLOSE:
-            bridge.stop();
-            bridge = null;
-            break;
-        default:
-            // Nothing
-        }
-    }
-
-    @Override
-    public synchronized List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,
-            boolean isActive) throws Exception {
-
-        if (translationText == null || !isEnabled()) {
-            // Return when disabled or translation text is empty
-            return null;
-        }
-
-        // LanguageTool claims to expect text in NFKC, but that actually causes problems for some rules:
-        // https://github.com/languagetool-org/languagetool/issues/379
-        // From the discussion it seems the intent behind NFKC was to break up multi-letter codepoints such as
-        // U+FB00 LATIN SMALL LIGATURE FF. These are unlikely to be found in user input in our case, so
-        // instead we will use NFC. We already normalize our source to NFC when loading, so we only need to
-        // handle the translation here:
-        translationText = StringUtil.normalizeUnicode(translationText);
-
-        // sourceText represents the displayed source text: it may be null (not
-        // displayed) or have extra bidi characters for display. Since we need
-        // it for linguistic comparison here, if it's null then we pull from the
-        // SourceTextEntry, which is guaranteed not to be null.
-        // It doesn't need to be normalized because OmegaT normalizes all source
-        // text to NFC on load.
-        if (sourceText == null) {
-            sourceText = ste.getSrcText();
-        }
-
-        return bridge.getMarksForEntry(ste, sourceText, translationText);
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        if (!Core.getProject().isProjectLoaded()) {
-            return;
-        }
-        // This property is changed in the end of configuration dialog saving,
-        // so at this point every other related properties are already changed.
-        if (evt.getPropertyName().equals(Preferences.LANGUAGETOOL_BRIDGE_TYPE)) {
-            setBridgeFromCurrentProject();
-        }
     }
 }

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -166,12 +166,6 @@ public class Preferences {
     public static final String TAGVWINDOW_X = "tagv_window_x";
     public static final String TAGVWINDOW_Y = "tagv_window_y";
 
-    // Help window size and position
-    public static final String HELPWINDOW_WIDTH = "help_window_width";
-    public static final String HELPWINDOW_HEIGHT = "help_window_height";
-    public static final String HELPWINDOW_X = "help_window_x";
-    public static final String HELPWINDOW_Y = "help_window_y";
-
     /** Use the TAB button to advance to the next segment */
     public static final String USE_TAB_TO_ADVANCE = "tab_advance";
     /** Always confirm Quit, even if the project is saved */

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -103,10 +103,7 @@ public class Preferences {
     public static final String MAINWINDOW_LAYOUT = "docking_layout";
 
     // Project files window size and position
-    public static final String PROJECT_FILES_WINDOW_WIDTH = "project_files_window_width";
-    public static final String PROJECT_FILES_WINDOW_HEIGHT = "project_files_window_height";
-    public static final String PROJECT_FILES_WINDOW_X = "project_files_window_x";
-    public static final String PROJECT_FILES_WINDOW_Y = "project_files_window_y";
+    public static final String PROJECT_FILES_WINDOW_GEOMETRY_PREFIX = "project_files_window";
     // Using the main font for the Project Files window
     public static final String PROJECT_FILES_USE_FONT = "project_files_use_font";
     // Determines whether or not the Project Files window is shown on project load.

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -114,10 +114,7 @@ public class Preferences {
     public static final String PROJECT_FILES_SHOW_ON_LOAD = "project_files_show_on_load";
 
     // Search window size and position
-    public static final String SEARCHWINDOW_WIDTH = "search_window_width";
-    public static final String SEARCHWINDOW_HEIGHT = "search_window_height";
-    public static final String SEARCHWINDOW_X = "search_window_x";
-    public static final String SEARCHWINDOW_Y = "search_window_y";
+    public static final String SEARCHWINDOW_GEOMETRY_PREFIX = "search_window";
     public static final String SEARCHWINDOW_SEARCH_TYPE = "search_window_search_type";
     public static final String SEARCHWINDOW_REPLACE_TYPE = "search_window_replace_type";
     public static final String SEARCHWINDOW_CASE_SENSITIVE = "search_window_case_sensitive";

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -99,10 +99,7 @@ public class Preferences {
     public static final String GLOSSARY_REPLACE_ON_INSERT = "glossary_replace_on_insert";
     public static final String DICTIONARY_FUZZY_MATCHING = "dictionary_fuzzy_matching";
 
-    public static final String MAINWINDOW_WIDTH = "screen_width";
-    public static final String MAINWINDOW_HEIGHT = "screen_height";
-    public static final String MAINWINDOW_X = "screen_x";
-    public static final String MAINWINDOW_Y = "screen_y";
+    public static final String MAINWINDOW_GEOMETRY_PREFIX = "screen";
     public static final String MAINWINDOW_LAYOUT = "docking_layout";
 
     // Project files window size and position

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -285,11 +285,8 @@ public class Preferences {
     public static final String SCRIPTS_QUICK_0 = "scripts_quick_0";
 
     /** Script window */
-    public static final String SCRIPTWINDOW_WIDTH = "script_window_width";
-    public static final String SCRIPTWINDOW_HEIGHT = "script_window_height";
-    public static final String SCRIPTWINDOW_X = "script_window_x";
-    public static final String SCRIPTWINDOW_Y = "script_window_y";
-    
+    public static final String SCRIPTWINDOW_GEOMETRY_PREFIX = "script_window";
+
     /** Most recent projects list */
     public static final String MOST_RECENT_PROJECTS_SIZE = "most_recent_projects_size";
     public static final String MOST_RECENT_PROJECTS_PREFIX = "most_recent_projects_";

--- a/src/org/omegat/util/StreamUtil.java
+++ b/src/org/omegat/util/StreamUtil.java
@@ -29,6 +29,8 @@ import java.text.Collator;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 public class StreamUtil {
 
@@ -77,5 +79,10 @@ public class StreamUtil {
                 return o1.compareToIgnoreCase(o2);
             }
         };
+    }
+
+    public static <T> Predicate<T> patternFilter(String regex, Function<T, String> stringExtractor) {
+        Pattern p = Pattern.compile(regex);
+        return o -> p.matcher(stringExtractor.apply(o)).matches();
     }
 }

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -151,7 +151,6 @@ public class JTextPaneLinkifier {
         
         static {
             MutableAttributeSet tmp = new SimpleAttributeSet();
-            tmp = new SimpleAttributeSet();
             StyleConstants.setUnderline(tmp, true);
             StyleConstants.setForeground(tmp, Styles.EditorColor.COLOR_HYPERLINK.getColor());
             LINK_ATTRIBUTES = tmp;

--- a/src/org/omegat/util/gui/StaticUIUtils.java
+++ b/src/org/omegat/util/gui/StaticUIUtils.java
@@ -43,7 +43,10 @@ import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.WindowEvent;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -263,15 +266,23 @@ public class StaticUIUtils {
      * @param isEnabled
      *            Enabled or not
      */
-    public static void setHierarchyEnabled(JComponent parent, boolean isEnabled) {
-        parent.setEnabled(isEnabled);
-        for (Component child : parent.getComponents()) {
-            if (child instanceof JComponent) {
-                setHierarchyEnabled((JComponent) child, isEnabled);
-            } else {
-                child.setEnabled(isEnabled);
+    public static void setHierarchyEnabled(Component parent, boolean isEnabled) {
+        visitHierarchy(parent, c -> c.setEnabled(isEnabled));
+    }
+
+    public static void visitHierarchy(Component parent, Consumer<Component> consumer) {
+        consumer.accept(parent);
+        if (parent instanceof JComponent) {
+            for (Component child : ((JComponent) parent).getComponents()) {
+                visitHierarchy(child, consumer);
             }
         }
+    }
+
+    public static List<Component> listHierarchy(Component parent) {
+        List<Component> cs = new ArrayList<>();
+        visitHierarchy(parent, cs::add);
+        return cs;
     }
 
     private static Optional<Rectangle> getStoredRectangle(String key) {

--- a/src/org/omegat/util/gui/TableColumnSizer.java
+++ b/src/org/omegat/util/gui/TableColumnSizer.java
@@ -146,7 +146,9 @@ public class TableColumnSizer {
                 }
                 if (shouldAdjust) {
                     reset();
-                    adjustTableColumns();
+                    // Queue up the adjustment because when the table has a
+                    // RowSorter things can be out of sync at this point.
+                    SwingUtilities.invokeLater(TableColumnSizer.this::adjustTableColumns);
                 }
             }
         });

--- a/test/src/org/omegat/core/tagvalidation/TagRepairTest.java
+++ b/test/src/org/omegat/core/tagvalidation/TagRepairTest.java
@@ -60,7 +60,7 @@ public class TagRepairTest extends TestCase {
         TagRepair.fixMissing(TagValidationTest.getList(tags3), text, new Tag(-1, "{tag1}"));
         assertEquals("Foo bar baz{tag1}", text.toString());
         
-        // Fix maformed
+        // Fix malformed
         text = new StringBuilder("Foo bar {tag2}baz{tag1}");
         String[] tags4 = {"{tag1}", "{tag2}"};
         TagRepair.fixMalformed(TagValidationTest.getList(tags4), text, new Tag(-1, "{tag1}"));

--- a/test/src/org/omegat/core/tagvalidation/TagValidationTest.java
+++ b/test/src/org/omegat/core/tagvalidation/TagValidationTest.java
@@ -28,9 +28,6 @@ package org.omegat.core.tagvalidation;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.omegat.core.data.EntryKey;
-import org.omegat.core.data.ProtectedPart;
-import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.tagvalidation.ErrorReport.TagError;
 import org.omegat.util.Preferences;
 import org.omegat.util.TagUtil.Tag;
@@ -48,7 +45,7 @@ public class TagValidationTest extends TestCase {
         // No errors
         String[] srcTags = {"<g0>", "<g1>", "</g1>", "</g0>"};
         String[] locTags = {"<g0>", "<g1>", "</g1>", "</g0>"};
-        ErrorReport report = new ErrorReport(null, null);
+        ErrorReport report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags), getList(locTags), false, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.isEmpty());
@@ -56,7 +53,7 @@ public class TagValidationTest extends TestCase {
         // Missing </g0>
         String[] srcTags2 = {"<g0>", "<g1>", "</g1>", "</g0>"};
         String[] locTags2 = {"<g0>", "<g1>", "</g1>"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags2), getList(locTags2), false, report);
         assertTrue(report.srcErrors.get(tag("</g0>")) == TagError.MISSING);
         assertTrue(report.transErrors.get(tag("<g0>")) == TagError.ORPHANED);
@@ -64,7 +61,7 @@ public class TagValidationTest extends TestCase {
         // Count mismatch </g0>
         String[] srcTags3 = {"<g0>", "<g1>", "</g1>", "</g0>"};
         String[] locTags3 = {"<g0>", "<g1>", "</g1>", "</g0>", "</g0>"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags3), getList(locTags3), false, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.get(tag("</g0>")) == TagError.DUPLICATE);
@@ -72,7 +69,7 @@ public class TagValidationTest extends TestCase {
         // Extraneous <x2/>
         String[] srcTags4 = {"<g0>", "<g1>", "</g1>", "</g0>"};
         String[] locTags4 = {"<g0>", "<g1>", "<x2/>", "</g1>", "</g0>"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags4), getList(locTags4), false, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.get(tag("<x2/>")) == TagError.EXTRANEOUS);
@@ -80,7 +77,7 @@ public class TagValidationTest extends TestCase {
         // Bad nesting <g1></g1>
         String[] srcTags5 = {"<g0>", "</g0>", "<g1>", "</g1>"};
         String[] locTags5 = {"<g0>", "</g0>", "</g1>", "<g1>"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags5), getList(locTags5), false, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.get(tag("<g1>")) == TagError.MALFORMED);
@@ -89,14 +86,14 @@ public class TagValidationTest extends TestCase {
         // Out of order <g1></g1>
         String[] srcTags6 = {"<g0>", "</g0>", "<g1>", "</g1>"};
         String[] locTags6 = {"<g1>", "</g1>", "<g0>", "</g0>"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags6), getList(locTags6), false, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.get(tag("<g1>")) == TagError.ORDER);
         assertTrue(report.transErrors.get(tag("</g1>")) == TagError.ORDER);
         
         // Out of order <g1></g1> with loose ordering
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags6), getList(locTags6), true, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.srcErrors.isEmpty());
@@ -106,7 +103,7 @@ public class TagValidationTest extends TestCase {
         // No errors
         String[] srcTags = {"a", "b", "c", "d"};
         String[] locTags = {"a", "b", "c", "d"};
-        ErrorReport report = new ErrorReport(null, null);
+        ErrorReport report = new ErrorReport();
         TagValidation.inspectUnorderedTags(getList(srcTags), getList(locTags), report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.isEmpty());
@@ -114,7 +111,7 @@ public class TagValidationTest extends TestCase {
         // Missing d
         String[] srcTags2 = {"a", "b", "c", "d"};
         String[] locTags2 = {"a", "b", "c"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectUnorderedTags(getList(srcTags2), getList(locTags2), report);
         assertTrue(report.srcErrors.get(tag("d")) == TagError.MISSING);
         assertTrue(report.transErrors.isEmpty());
@@ -122,7 +119,7 @@ public class TagValidationTest extends TestCase {
         // No error for unordered: Count mismatch d
         String[] srcTags3 = {"a", "b", "c", "d"};
         String[] locTags3 = {"a", "b", "c", "d", "d"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectUnorderedTags(getList(srcTags3), getList(locTags3), report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.isEmpty());
@@ -130,7 +127,7 @@ public class TagValidationTest extends TestCase {
         // Extraneous e
         String[] srcTags4 = {"a", "b", "c", "d"};
         String[] locTags4 = {"a", "b", "e", "c", "d"};
-        report = new ErrorReport(null, null);
+        report = new ErrorReport();
         TagValidation.inspectOrderedTags(getList(srcTags4), getList(locTags4), false, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.get(tag("e")) == TagError.EXTRANEOUS);
@@ -139,20 +136,20 @@ public class TagValidationTest extends TestCase {
     public void testPrintfTagValidation() {
         
         // No error
-        ErrorReport report = makeReport("Foo %s bar %d", "Foo %s bar %d");
+        ErrorReport report = new ErrorReport("Foo %s bar %d", "Foo %s bar %d");
         TagValidation.inspectPrintfVariables(true, report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.isEmpty());
         
         // Missing %d
-        report = makeReport("Foo %s bar %d", "Foo %s bar");
+        report = new ErrorReport("Foo %s bar %d", "Foo %s bar");
         TagValidation.inspectPrintfVariables(true, report);
         assertTrue(report.srcErrors.get(new Tag(4, "%s")) == TagError.UNSPECIFIED);
         assertTrue(report.srcErrors.get(new Tag(11, "%d")) == TagError.UNSPECIFIED);
         assertTrue(report.transErrors.get(new Tag(4, "%s")) == TagError.UNSPECIFIED);
         
         // Extraneous %d
-        report = makeReport("Foo %s bar %d", "Foo %s bar %d baz %d");
+        report = new ErrorReport("Foo %s bar %d", "Foo %s bar %d baz %d");
         TagValidation.inspectPrintfVariables(true, report);
         assertTrue(report.srcErrors.get(new Tag(4, "%s")) == TagError.UNSPECIFIED);
         assertTrue(report.srcErrors.get(new Tag(11, "%d")) == TagError.UNSPECIFIED);
@@ -166,13 +163,13 @@ public class TagValidationTest extends TestCase {
         Preferences.setPreference(Preferences.CHECK_REMOVE_PATTERN, "foo");
         
         // No error
-        ErrorReport report = makeReport("foo bar baz", "bar baz");
+        ErrorReport report = new ErrorReport("foo bar baz", "bar baz");
         TagValidation.inspectRemovePattern(report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.isEmpty());
         
         // Extraneous foo
-        report = makeReport("foo bar baz", "foo bar baz");
+        report = new ErrorReport("foo bar baz", "foo bar baz");
         TagValidation.inspectRemovePattern(report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.get(new Tag(0, "foo")) == TagError.EXTRANEOUS);
@@ -188,12 +185,5 @@ public class TagValidationTest extends TestCase {
     
     private static Tag tag(String tag) {
         return new Tag(-1, tag);
-    }
-    
-    private ErrorReport makeReport(String source, String translation) {
-        EntryKey key = new EntryKey(null, source, null, null, null, null);
-        SourceTextEntry ste = new SourceTextEntry(key, 0, null, null, new ArrayList<ProtectedPart>());
-        ErrorReport report = new ErrorReport(ste, translation);
-        return report;
     }
 }

--- a/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
@@ -89,7 +89,7 @@ public class GlossaryTextAreaTest extends TestCore {
             }
         });
         assertFalse(gta.getText().isEmpty());
-        SwingUtilities.invokeAndWait(() -> gta.clear());
+        SwingUtilities.invokeAndWait(gta::clear);
         assertTrue(gta.getText().isEmpty());
     }
 

--- a/test/src/org/omegat/languagetools/FalseFriendsTest.java
+++ b/test/src/org/omegat/languagetools/FalseFriendsTest.java
@@ -40,9 +40,9 @@ import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.data.TMXEntry.ExternalLinked;
-import org.omegat.core.events.IProjectEventListener.PROJECT_CHANGE_TYPE;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.gui.editor.mark.Mark;
+import org.omegat.languagetools.LanguageToolWrapper.LanguageToolMarker;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.util.Language;
 
@@ -165,37 +165,34 @@ public class FalseFriendsTest extends TestCore {
                 return null;
             }
         });
+        LanguageToolWrapper.setBridgeFromCurrentProject();
     }
 
     @Test
     public void testExecute() throws Exception {
-        LanguageToolWrapper wrapper = new LanguageToolWrapper() {
+        LanguageToolMarker marker = new LanguageToolMarker() {
             public boolean isEnabled() {
                 return true;
             };
         };
 
-        wrapper.onProjectChanged(PROJECT_CHANGE_TYPE.LOAD);
-
-        List<Mark> marks = wrapper.getMarksForEntry(null, "This is abnegation.", "To jest abnegacja.", true);
+        List<Mark> marks = marker.getMarksForEntry(null, "This is abnegation.", "To jest abnegacja.", true);
         assertEquals(1, marks.size());
         assertTrue(marks.get(0).toolTipText.contains("slovenliness"));
     }
 
     @Test
     public void testRemoveRules() throws Exception {
-        LanguageToolWrapper wrapper = new LanguageToolWrapper() {
+        LanguageToolMarker marker = new LanguageToolMarker() {
             public boolean isEnabled() {
                 return true;
             };
         };
 
-        wrapper.onProjectChanged(PROJECT_CHANGE_TYPE.LOAD);
-
-        List<Mark> marks = wrapper.getMarksForEntry(null, "This is some long text without translation.", "", true);
+        List<Mark> marks = marker.getMarksForEntry(null, "This is some long text without translation.", "", true);
         assertEquals(0, marks.size());
 
-        marks = wrapper.getMarksForEntry(null, "This is text with the same translation.",
+        marks = marker.getMarksForEntry(null, "This is text with the same translation.",
                 "This is text with the same translation.", true);
         assertEquals(0, marks.size());
     }

--- a/test/src/org/omegat/util/StaticUtilsTest.java
+++ b/test/src/org/omegat/util/StaticUtilsTest.java
@@ -28,6 +28,7 @@
 package org.omegat.util;
 
 import java.io.File;
+import java.util.regex.Pattern;
 
 import junit.framework.TestCase;
 
@@ -64,5 +65,20 @@ public class StaticUtilsTest extends TestCase {
         for (String dir : new String[] { "src", "docs", "lib" }) {
             assertTrue(new File(installDir, dir).isDirectory());
         }
+    }
+
+    public void testGlobToRegex() {
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab?d"), "abcd"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("ab?d"), "abd"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*d"), "abcccccd"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*d"), "abd"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("ab*d"), "abde"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*"), "abdefg"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("$a[b-c]!?*d{}"), "$a[b-c]!?1234d{}"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a?"), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a ?"), "a b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a*"), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a* b"), "a b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a*b"), "a b"));
     }
 }

--- a/test/src/org/omegat/util/StaticUtilsTest.java
+++ b/test/src/org/omegat/util/StaticUtilsTest.java
@@ -68,17 +68,29 @@ public class StaticUtilsTest extends TestCase {
     }
 
     public void testGlobToRegex() {
-        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab?d"), "abcd"));
-        assertFalse(Pattern.matches(StaticUtils.globToRegex("ab?d"), "abd"));
-        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*d"), "abcccccd"));
-        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*d"), "abd"));
-        assertFalse(Pattern.matches(StaticUtils.globToRegex("ab*d"), "abde"));
-        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*"), "abdefg"));
-        assertTrue(Pattern.matches(StaticUtils.globToRegex("$a[b-c]!?*d{}"), "$a[b-c]!?1234d{}"));
-        assertFalse(Pattern.matches(StaticUtils.globToRegex("a?"), "a b"));
-        assertTrue(Pattern.matches(StaticUtils.globToRegex("a ?"), "a b"));
-        assertFalse(Pattern.matches(StaticUtils.globToRegex("a*"), "a b"));
-        assertTrue(Pattern.matches(StaticUtils.globToRegex("a* b"), "a b"));
-        assertFalse(Pattern.matches(StaticUtils.globToRegex("a*b"), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab?d", false), "abcd"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("ab?d", false), "abd"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*d", false), "abcccccd"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*d", false), "abd"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("ab*d", false), "abde"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("ab*", false), "abdefg"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("$a[b-c]!?*d{}", false), "$a[b-c]!?1234d{}"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a?", false), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a ?", false), "a b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a*", false), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a* b", false), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a* b", true), "a b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a*b", false), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a*b", false), "a\u00A0b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a*b", true), "a\u00A0b"));
+
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a b", false), "a b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a b", true), "a b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a b", false), "a\u00A0b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a b", true), "a\u00A0b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a *", false), "a\u00A0b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a *", true), "a\u00A0b"));
+        assertFalse(Pattern.matches(StaticUtils.globToRegex("a ?", false), "a\u00A0b"));
+        assertTrue(Pattern.matches(StaticUtils.globToRegex("a ?", true), "a\u00A0b"));
     }
 }


### PR DESCRIPTION
Sorry to keep pulling the rug out from under you.

I've pulled in the latest master and resolved the conflicts with my changes. My changes on master were in preparation for an "Issues" window that aggregates all problems (bad tags, misspellings, LT suggestions) in the project into one window.

LanguageTool issues are the slowest to check, so I am doing it with a `parallelStream`. Since `JLanguageTool` is not thread-safe, I wrapped them in `ThreadLocal`s so that each stream thread gets its own instance.

Just now I noticed the existence of `MultiThreadedJLanguageTool`, which uses its own thread pool, but I am worried that using this inside a `parallelStream` will just explode the thread count so it's better to do it with a local `JLanguageTool` per stream thread. Do you have any experience in this area?

> Also ThreadLocal memebers are non-static there which puzzles me too. Is there any reason for this?

They might as well have been static given how `LanguageToolWrapper` is (was) designed and how OmegaT uses projects as global state at the moment. On master only ever have one `LanguageToolWrapper` so it doesn't really matter. I think I was looking ahead to your work when I wrote it that way.

With your work, LT for a given language pair is encapsulated in bridge instances. We pass in the languages, which are thus state, and must be held per-instance. In the future we might support handling multiple projects at once, each of which will need a bridge instance with its own `ThreadLocal`s. Does that make sense?

To reflect the changed role of `LanguageToolWrapper` on your branch I have refactored it to be a wrapper around a static bridge instance with only static methods.
